### PR TITLE
Compressor hotfix

### DIFF
--- a/OASMan_ESP32/src/bluetooth/ps3_controller.cpp
+++ b/OASMan_ESP32/src/bluetooth/ps3_controller.cpp
@@ -163,7 +163,7 @@ void passUpDriverDown(int ms)
 void doDance()
 {
     Serial.println("Doing dance sequence!");
-    int timing = 750;
+    int timing = 600;
     // initialize by dropping for half the time of one side
     passUpDriverDown(timing / 2);
     for (int i = 0; i < 5; i++)

--- a/OASMan_ESP32/src/components/solenoid.cpp
+++ b/OASMan_ESP32/src/components/solenoid.cpp
@@ -7,11 +7,14 @@ Solenoid::Solenoid() {}
 Solenoid::Solenoid(InputType *pin)
 {
     this->pin = pin;
+
+    // default solenoid to low state... this is important after a software reboot, it could be stuck as HIGH because it is not automatically reset to LOW
     this->bopen = false;
+    this->pin->digitalWrite(LOW);
 }
 void Solenoid::open()
 {
-    if (this->bopen == false || (this->pin->digitalRead() != HIGH))
+    if (this->bopen == false)
     {
         this->pin->digitalWrite(HIGH);
         this->bopen = true;
@@ -19,7 +22,7 @@ void Solenoid::open()
 }
 void Solenoid::close()
 {
-    if (this->bopen == true || (this->pin->digitalRead() != LOW))
+    if (this->bopen == true)
     {
         this->pin->digitalWrite(LOW);
         this->bopen = false;

--- a/OASMan_ESP32/src/components/solenoid.cpp
+++ b/OASMan_ESP32/src/components/solenoid.cpp
@@ -11,7 +11,7 @@ Solenoid::Solenoid(InputType *pin)
 }
 void Solenoid::open()
 {
-    if (this->bopen == false)
+    if (this->bopen == false || (this->pin->digitalRead() != HIGH))
     {
         this->pin->digitalWrite(HIGH);
         this->bopen = true;
@@ -19,7 +19,7 @@ void Solenoid::open()
 }
 void Solenoid::close()
 {
-    if (this->bopen == true)
+    if (this->bopen == true || (this->pin->digitalRead() != LOW))
     {
         this->pin->digitalWrite(LOW);
         this->bopen = false;

--- a/OASMan_ESP32/src/tasks/tasks.cpp
+++ b/OASMan_ESP32/src/tasks/tasks.cpp
@@ -137,7 +137,7 @@ void setup_tasks()
     xTaskCreate(
         task_compressor,
         "Compressor Control",
-        512 * 6, // 4-2-2025 hotfix attempt, increased from 4 to 6. Compressor would sometimes not turn off. Theory is thread is crashing from running out of memory, as this seems to be a common crash issue in the past. Simply out of memory
+        512 * 4,
         NULL,
         1000,
         NULL);

--- a/OASMan_ESP32/src/tasks/tasks.cpp
+++ b/OASMan_ESP32/src/tasks/tasks.cpp
@@ -137,7 +137,7 @@ void setup_tasks()
     xTaskCreate(
         task_compressor,
         "Compressor Control",
-        512 * 4,
+        512 * 6, // 4-2-2025 hotfix attempt, increased from 4 to 6. Compressor would sometimes not turn off. Theory is thread is crashing from running out of memory, as this seems to be a common crash issue in the past. Simply out of memory
         NULL,
         1000,
         NULL);


### PR DESCRIPTION
Fix bug where it can stay on and go over pressure after a reboot.
Reproduction steps:
Turn compressor on
Connect ps3 controller
Let tank pressure get somewhere between your on pressure and your off pressure. Ie, default it turns on at 140 and off at 180, so let it get to 170.
On the ps3 controller press start + select to do a quick software reboot.
Notice: compressor doesn't turn off after reboot, and proceceds to overfill over 180
Reason: digitalWrite was HIGH before reboot, and was assumed to reset to LOW after reboot, but it was not. bopen was set to false, so it thought it was LOW. When it then tried to write LOW at 180, it thought it was already LOW and thus didn't call digitalWrite.