### PR TITLE
Controller performance boost

### DIFF
--- a/Wireless_Controller/device_libs/ws1p8knob/files/LVGL_Driver.cpp
+++ b/Wireless_Controller/device_libs/ws1p8knob/files/LVGL_Driver.cpp
@@ -5,13 +5,15 @@
 #include "esp_heap_caps.h"
 
 // Partial strips only: full-frame SPI TX needs huge spi_master internal DMA "priv" buffers and fails on this chip (setup_dma_priv_buffer).
-// Draw buffers live in PSRAM; flush path calls esp_cache_msync before SPI reads them.
+// Prefer internal DMA RAM (2x 17.3KB fits): rendering is faster than PSRAM and the flush path
+// skips the esp_cache_msync that PSRAM buffers need. PSRAM stays as fallback.
+// ; was: MALLOC_CAP_DMA|MALLOC_CAP_SPIRAM tried first
 static lv_color_t *alloc_draw_buf(void)
 {
     const size_t n = (size_t)LVGL_BUF_BYTES;
-    void *p = heap_caps_malloc(n, MALLOC_CAP_DMA | MALLOC_CAP_SPIRAM);
+    void *p = heap_caps_malloc(n, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
     if (!p)
-        p = heap_caps_malloc(n, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
+        p = heap_caps_malloc(n, MALLOC_CAP_DMA | MALLOC_CAP_SPIRAM);
     if (!p)
         p = malloc(n);
     return (lv_color_t *)p;

--- a/Wireless_Controller/device_libs/ws1p8knob/files/LVGL_Driver.h
+++ b/Wireless_Controller/device_libs/ws1p8knob/files/LVGL_Driver.h
@@ -11,7 +11,10 @@
 #define LVGL_HEIGHT LCD_HEIGHT
 // Must equal SH8601_LVGL_PARTIAL_LINES in Display_SH8601.h (SPI max_transfer_sz).
 #define LVGL_PARTIAL_LINES SH8601_LVGL_PARTIAL_LINES
-#define LVGL_BUF_BYTES ((uint32_t)((size_t)LVGL_WIDTH * (size_t)LVGL_PARTIAL_LINES * sizeof(lv_color_t)))
+// RGB565 = 2 bytes/px, matching SH8601_MAX_TRANSFER_SZ exactly.
+// ; was: * sizeof(lv_color_t) (3 bytes in LVGL 9), which let LVGL fit 36 rows in the buffer —
+// a single flush could then exceed the SPI max_transfer_sz sized for 24 rows.
+#define LVGL_BUF_BYTES ((uint32_t)((size_t)LVGL_WIDTH * (size_t)LVGL_PARTIAL_LINES * 2))
 
 #define EXAMPLE_LVGL_TICK_PERIOD_MS 2
 

--- a/Wireless_Controller/device_libs/ws2p8/files/LVGL_Driver.cpp
+++ b/Wireless_Controller/device_libs/ws2p8/files/LVGL_Driver.cpp
@@ -1,9 +1,22 @@
 #include "LVGL_Driver.h"
+#include <Arduino.h>
 
-// static lv_color_t buf1[LVGL_BUF_LEN];
-// static lv_color_t buf2[LVGL_BUF_LEN];
-static lv_color_t* buf1 = (lv_color_t*) heap_caps_malloc(LVGL_BUF_LEN, MALLOC_CAP_SPIRAM);
-static lv_color_t* buf2 = (lv_color_t*) heap_caps_malloc(LVGL_BUF_LEN, MALLOC_CAP_SPIRAM);
+// Prefer internal RAM: LVGL software-renders into these buffers, and internal RAM is much
+// faster than PSRAM. 2x 19.2KB fits easily. No cache sync needed on the PSRAM fallback —
+// the flush path is CPU-driven Arduino SPI (transferBytes), not DMA.
+// ; was: two full-frame (153.6KB) buffers in MALLOC_CAP_SPIRAM
+static lv_color_t *alloc_draw_buf(void)
+{
+  void *p = heap_caps_malloc(LVGL_BUF_BYTES, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
+  if (!p)
+    p = heap_caps_malloc(LVGL_BUF_BYTES, MALLOC_CAP_SPIRAM);
+  if (!p)
+    p = malloc(LVGL_BUF_BYTES);
+  return (lv_color_t *)p;
+}
+
+static lv_color_t *buf1 = nullptr;
+static lv_color_t *buf2 = nullptr;
 
 /* Serial debugging */
 void Lvgl_print(const char *buf)
@@ -53,13 +66,22 @@ void example_increase_lvgl_tick(void *arg)
 
 touch_and_screen Lvgl_Init(void)
 {
+  if (!buf1)
+    buf1 = alloc_draw_buf();
+  if (!buf2)
+    buf2 = alloc_draw_buf();
+  if (!buf1 || !buf2)
+    Serial.println("[LVGL] FATAL: display buffer alloc failed");
+
   lv_init();
 
   /*Initialize the display*/
   static lv_display_t *disp = lv_display_create(LVGL_WIDTH, LVGL_HEIGHT);
   lv_display_set_flush_cb(disp, Lvgl_Display_LCD);
-  lv_display_set_buffers(disp, buf1, buf2, LVGL_BUF_LEN * sizeof(lv_color_t), LV_DISPLAY_RENDER_MODE_PARTIAL);
-  lv_display_set_render_mode(disp, LV_DISPLAY_RENDER_MODE_FULL); /**< Always make the whole screen redrawn*/
+  // PARTIAL: only dirty areas are rendered and pushed over SPI, instead of re-rendering and
+  // re-transmitting the whole 153.6KB frame (>15ms of blocking wire time) on every refresh.
+  // ; was: full-frame buffers + lv_display_set_render_mode(disp, LV_DISPLAY_RENDER_MODE_FULL)
+  lv_display_set_buffers(disp, buf1, buf2, LVGL_BUF_BYTES, LV_DISPLAY_RENDER_MODE_PARTIAL);
 
   /*Initialize the (dummy) input device driver*/
   static lv_indev_t *indev = lv_indev_create();

--- a/Wireless_Controller/device_libs/ws2p8/files/LVGL_Driver.cpp
+++ b/Wireless_Controller/device_libs/ws2p8/files/LVGL_Driver.cpp
@@ -82,6 +82,12 @@ touch_and_screen Lvgl_Init(void)
   // re-transmitting the whole 153.6KB frame (>15ms of blocking wire time) on every refresh.
   // ; was: full-frame buffers + lv_display_set_render_mode(disp, LV_DISPLAY_RENDER_MODE_FULL)
   lv_display_set_buffers(disp, buf1, buf2, LVGL_BUF_BYTES, LV_DISPLAY_RENDER_MODE_PARTIAL);
+  // 60 FPS refresh: bench-verified with the perf overlay after the PARTIAL switch — idle CPU
+  // 2-4%, page-change peaks ~35% at 30 FPS, so doubling the refresh rate has ample headroom.
+  // ; was: LV_DEF_REFR_PERIOD default (33ms / 30 FPS)
+  lv_timer_t *refr = lv_display_get_refr_timer(disp);
+  if (refr)
+    lv_timer_set_period(refr, 16);
 
   /*Initialize the (dummy) input device driver*/
   static lv_indev_t *indev = lv_indev_create();

--- a/Wireless_Controller/device_libs/ws2p8/files/LVGL_Driver.h
+++ b/Wireless_Controller/device_libs/ws2p8/files/LVGL_Driver.h
@@ -9,7 +9,15 @@
 
 #define LVGL_WIDTH LCD_WIDTH
 #define LVGL_HEIGHT LCD_HEIGHT
-#define LVGL_BUF_LEN (LVGL_WIDTH * LVGL_HEIGHT * 2) // originally /20, /4 also wouldn't work, *1 worked with lots of lag and crashes, *2 works smoothly
+// Partial render buffers: 40 lines each, sized in BYTES (RGB565 = 2 bytes/px).
+// The old full-frame config mixed units: heap_caps_malloc() was given LVGL_BUF_LEN bytes but
+// lv_display_set_buffers() was told LVGL_BUF_LEN * sizeof(lv_color_t) (3 bytes in LVGL 9),
+// declaring 3x more buffer than was actually allocated. That overrun is why the earlier
+// partial-buffer attempts (/20, /4) "crashed"; FULL render mode only survived because LVGL
+// caps its usage at the real frame size in that mode.
+// ; was: #define LVGL_BUF_LEN (LVGL_WIDTH * LVGL_HEIGHT * 2)  (full frame, FULL render mode)
+#define LVGL_BUF_LINES 40
+#define LVGL_BUF_BYTES ((uint32_t)LVGL_WIDTH * LVGL_BUF_LINES * 2)
 
 #define EXAMPLE_LVGL_TICK_PERIOD_MS 2
 

--- a/Wireless_Controller/device_libs/ws2p8b/files/LVGL_Driver.cpp
+++ b/Wireless_Controller/device_libs/ws2p8b/files/LVGL_Driver.cpp
@@ -71,16 +71,23 @@ touch_and_screen Lvgl_Init(void)
 
   // Use a smaller, DMA-capable partial draw buffer to avoid full-frame copies on large RGB panels.
   // (The RGB panel driver maintains its own frame buffer; we just blit updated areas via draw_bitmap.)
-  if (!buf1) buf1 = (lv_color_t*)heap_caps_malloc(LVGL_BUF_LEN * sizeof(lv_color_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA);
+  if (!buf1) buf1 = (lv_color_t*)heap_caps_malloc(LVGL_BUF_BYTES, MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA); // ; was: LVGL_BUF_LEN * sizeof(lv_color_t)
   // On ws2p8b internal RAM can be tight; prefer single buffering to leave heap for other subsystems (e.g. ADC locks).
   // buf2 = NULL;
-  if (!buf2) buf2 = (lv_color_t*)heap_caps_malloc(LVGL_BUF_LEN * sizeof(lv_color_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA);
+  if (!buf2) buf2 = (lv_color_t*)heap_caps_malloc(LVGL_BUF_BYTES, MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA); // ; was: LVGL_BUF_LEN * sizeof(lv_color_t)
 
   /*Initialize the display*/
   disp = lv_display_create(LVGL_WIDTH, LVGL_HEIGHT);
   lv_display_set_flush_cb(disp, Lvgl_Display_LCD);
-  lv_display_set_buffers(disp, buf1, buf2, LVGL_BUF_LEN * sizeof(lv_color_t), LV_DISPLAY_RENDER_MODE_PARTIAL);
+  lv_display_set_buffers(disp, buf1, buf2, LVGL_BUF_BYTES, LV_DISPLAY_RENDER_MODE_PARTIAL); // ; was: LVGL_BUF_LEN * sizeof(lv_color_t)
   lv_display_set_user_data(disp, panel_handle); // unsure if this is necessary
+
+  // 60 FPS target: the RGB panel refreshes itself from its own frame buffers; LVGL only blits
+  // dirty strips, so a 16ms refresh period is sustainable. Same override ws1p8knob uses.
+  // ; was: LV_DEF_REFR_PERIOD default (33ms / 30 FPS)
+  lv_timer_t *refr = lv_display_get_refr_timer(disp);
+  if (refr)
+    lv_timer_set_period(refr, 16);
 
   /*Initialize the (dummy) input device driver*/
   lv_indev_t *indev = lv_indev_create();

--- a/Wireless_Controller/device_libs/ws2p8b/files/LVGL_Driver.h
+++ b/Wireless_Controller/device_libs/ws2p8b/files/LVGL_Driver.h
@@ -9,10 +9,12 @@
 
 #define LVGL_WIDTH     ESP_PANEL_LCD_WIDTH
 #define LVGL_HEIGHT    ESP_PANEL_LCD_HEIGHT
-// #define LVGL_BUF_LEN  (LVGL_WIDTH * LVGL_HEIGHT * sizeof(lv_color_t))
-// #define LVGL_BUF_LEN (LVGL_WIDTH * 40)
-// #define LVGL_BUF_LEN (LVGL_WIDTH * LVGL_HEIGHT)
-#define LVGL_BUF_LEN (LVGL_WIDTH * 20)
+// Partial draw buffers: 30 lines each, sized in BYTES (RGB565 = 2 bytes/px).
+// ; was: #define LVGL_BUF_LEN (LVGL_WIDTH * 20) in pixels, multiplied by sizeof(lv_color_t)
+// (3 bytes in LVGL 9) at the call sites — the same 28.8KB of memory, which LVGL divided by
+// the real 2-byte stride into 30 usable rows. Same size now, with honest units.
+#define LVGL_BUF_LINES 30
+#define LVGL_BUF_BYTES ((uint32_t)LVGL_WIDTH * LVGL_BUF_LINES * 2)
 
 #define EXAMPLE_LVGL_TICK_PERIOD_MS  2
 

--- a/Wireless_Controller/device_libs/ws3p5/files/lvgl_panel_st7796_ft6336.cpp
+++ b/Wireless_Controller/device_libs/ws3p5/files/lvgl_panel_st7796_ft6336.cpp
@@ -53,13 +53,20 @@ public:
 } // namespace
 
 // Partial buffer size tuned for internal RAM on Arduino_GFX 1.5.5
-#define LVGL_BUFFER_LINES   480
+// 60 lines x 320 px x 2 bytes = 38.4KB per buffer, so the internal-DMA allocation below can
+// actually succeed. ; was: 480 (full height) which with the old `* sizeof(lv_color_t)` math
+// (3 bytes in LVGL 9) asked for 460.8KB per buffer — internal alloc always failed and both
+// buffers silently fell back to slower PSRAM, 1.5x oversized.
+#define LVGL_BUFFER_LINES   60
 #define LVGL_BUFFER_PIXELS (LCD_WIDTH * LVGL_BUFFER_LINES)
 
 // ---------- Tunable ST7796 color correction ----------
 // Set to 0 to disable all software correction quickly.
 
-#define ST_ENABLE_COLOR_CORRECTION 1
+// Disabled: the LUT parameters below are all identity (brightness/gamma/gains = 1.0), so the
+// per-pixel transform in the flush path changed nothing while costing CPU on every flush.
+// Re-enable only together with real (non-1.0) calibration values. ; was: 1
+#define ST_ENABLE_COLOR_CORRECTION 0
 
 // ----------------------------------------------------
 
@@ -266,11 +273,11 @@ void lvgl_flush_cb(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map)
 {
   const uint32_t w = (uint32_t)(area->x2 - area->x1 + 1);
   const uint32_t h = (uint32_t)(area->y2 - area->y1 + 1);
-  const uint32_t count = w * h;
 
   uint16_t *src = (uint16_t *)px_map;
 
 #if ST_ENABLE_COLOR_CORRECTION
+  const uint32_t count = w * h;
   st_build_cc_luts();
 
   // In-place color correction
@@ -335,7 +342,9 @@ extern "C" lv_display_t *lvgl_lcd_init_perf(void)
 
   lv_tick_set_cb(lvgl_tick_cb);
 
-  const size_t buf_size = LVGL_BUFFER_PIXELS * sizeof(lv_color_t);
+  // RGB565 = 2 bytes/px. ; was: * sizeof(lv_color_t), which is 3 bytes in LVGL 9 — that both
+  // oversized the buffers by 1.5x and overstated the usable size passed to LVGL.
+  const size_t buf_size = LVGL_BUFFER_PIXELS * 2;
 
   // 1) Best: internal DMA
   lv_color_t *buf1 = (lv_color_t *)heap_caps_malloc(buf_size, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);

--- a/Wireless_Controller/device_libs/ws3p5b/files/lvgl_panel_axs15231b_arduino_gfx.cpp
+++ b/Wireless_Controller/device_libs/ws3p5b/files/lvgl_panel_axs15231b_arduino_gfx.cpp
@@ -117,6 +117,12 @@ void Set_Backlight(uint8_t Light);        // from LVGL_Driver.cpp
 #endif
 
 // OPTIMIZED: Smart frame skipping
+// Default OFF; overridable per-build with '-D ENABLE_FRAME_SKIP=1' (FRAMECHECK_SAMPLE_STRIDE
+// likewise). Worth trying on this panel: it requires FULL render mode, so every flush pushes
+// the whole 307KB frame over 60MHz QSPI (~41ms, ~20 FPS ceiling) even when nothing changed —
+// frame skip would eliminate those idle pushes. NOT yet verified on ws3p5b hardware: before
+// enabling, bench-check for tearing, stale regions after dialogs close, and touch-wake
+// responsiveness.
 #ifndef ENABLE_FRAME_SKIP
   #define ENABLE_FRAME_SKIP 0
 #endif

--- a/Wireless_Controller/include/lv_conf.h
+++ b/Wireless_Controller/include/lv_conf.h
@@ -761,14 +761,19 @@
 #define LV_USE_SNAPSHOT 0
 
 /*1: Enable system monitor component*/
-#define LV_USE_SYSMON   0
+/* Dev builds get the FPS/CPU overlay for performance work; compiled out of official releases. */
+#ifdef OFFICIAL_RELEASE
+    #define LV_USE_SYSMON   0
+#else
+    #define LV_USE_SYSMON   1 /* ; was: 0 */
+#endif
 #if LV_USE_SYSMON
     /*Get the idle percentage. E.g. uint32_t my_get_idle(void);*/
     #define LV_SYSMON_GET_IDLE lv_timer_get_idle
 
     /*1: Show CPU usage and FPS count
      * Requires `LV_USE_SYSMON = 1`*/
-    #define LV_USE_PERF_MONITOR 0
+    #define LV_USE_PERF_MONITOR 1 /* ; was: 0 */
     #if LV_USE_PERF_MONITOR
         #define LV_USE_PERF_MONITOR_POS LV_ALIGN_BOTTOM_RIGHT
 
@@ -825,7 +830,12 @@
 #define LV_USE_IMGFONT 0
 
 /*1: Enable an observer pattern implementation*/
-#define LV_USE_OBSERVER 0
+/* Required by LV_USE_SYSMON/LV_USE_PERF_MONITOR (dev-only FPS overlay). */
+#ifdef OFFICIAL_RELEASE
+    #define LV_USE_OBSERVER 0
+#else
+    #define LV_USE_OBSERVER 1 /* ; was: 0 */
+#endif
 
 /*1: Enable Pinyin input method*/
 /*Requires: lv_keyboard*/

--- a/Wireless_Controller/platformio.ini
+++ b/Wireless_Controller/platformio.ini
@@ -25,6 +25,8 @@ monitor_rts = 0
 monitor_dtr = 0
 monitor_filters = esp32_exception_decoder
 
+; fix for uploading on ws2p8b
+; ESP32-S3 Waveshare boards use native USB-Serial/JTAG (not a UART bridge).
 ; esptool's stub flasher can drop the USB link mid-flash on Windows ("chip stopped responding");
 ; --no-stub uses the ROM loader instead (slower upload, reliable). Web flasher is unaffected.
 ; was: no upload overrides (board default 115200 + hard_reset + stub flasher)

--- a/Wireless_Controller/platformio.ini
+++ b/Wireless_Controller/platformio.ini
@@ -25,8 +25,12 @@ monitor_rts = 0
 monitor_dtr = 0
 monitor_filters = esp32_exception_decoder
 
+; The framework appends its own -Os after user flags, which would silently override our -O2;
+; build_unflags strips it so -O2 below is the only optimization flag on the command line.
+build_unflags = -Os
 build_flags =
     -Wall
+    -O2 ; optimize for speed (LVGL software rendering is CPU-bound) ; was: framework default -Os
     -I include  ; Add the include/ folder to the search path, needed for lvgl 9.3+
     -D LV_CONF_INCLUDE_SIMPLE  ; Use simple include method for lv_conf.h (finds it via -I include)
     '-D BOARD_NAME="${this.board}"'
@@ -133,10 +137,13 @@ lib_deps = ${env.lib_deps}
 
 ; setup release envs
 [env:release]
-build_flags = 
+build_flags =
     '-D OFFICIAL_RELEASE'
     '-D RELEASE_VERSION=${sysenv.version_num}'
     '-D RELEASE_TAG_NAME=${sysenv.release_tag_name}'
+    ; Demote serial logging in releases; -U first avoids a macro-redefinition warning vs the INFO value inherited from [env] ; was: INFO in all builds
+    '-UCORE_DEBUG_LEVEL'
+    '-D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_WARN'
 
 [env:controller_ws2p8_release]
 extends = env:controller_ws2p8_dev

--- a/Wireless_Controller/platformio.ini
+++ b/Wireless_Controller/platformio.ini
@@ -25,6 +25,15 @@ monitor_rts = 0
 monitor_dtr = 0
 monitor_filters = esp32_exception_decoder
 
+; esptool's stub flasher can drop the USB link mid-flash on Windows ("chip stopped responding");
+; --no-stub uses the ROM loader instead (slower upload, reliable). Web flasher is unaffected.
+; was: no upload overrides (board default 115200 + hard_reset + stub flasher)
+upload_speed = 921600
+board_upload.after_reset = watchdog-reset
+upload_flags = --no-stub
+
+
+
 ; The framework appends its own -Os after user flags, which would silently override our -O2;
 ; build_unflags strips it so -O2 below is the only optimization flag on the command line.
 build_unflags = -Os

--- a/Wireless_Controller/src/bt/ble.cpp
+++ b/Wireless_Controller/src/bt/ble.cpp
@@ -404,8 +404,7 @@ bool connectToServer(const BLEAdvertisedDevice *myDevice)
             connectionErrorInfoString = "Auth timed out";
             return false;
         }
-        Serial.print(".");
-        delay(10);
+        delay(10); // was: also Serial.print(".") each iteration — blocked the BLE task on UART during auth
     }
 
     log_i("Connected Successfully");
@@ -559,7 +558,9 @@ void ble_loop()
         bool success = true;
         if (hasPacketToSend)
         {
-            packet.dump();
+#ifndef OFFICIAL_RELEASE
+            packet.dump(); // serial dump of the full packet; dev-only, blocks the BLE task on UART
+#endif
             success = pRemoteChar_Rest->writeValue(packet.tx(), BTOAS_PACKET_SIZE, true);
             log_i("Sent rest packet!");
         }

--- a/Wireless_Controller/src/main.cpp
+++ b/Wireless_Controller/src/main.cpp
@@ -277,6 +277,12 @@ void loop()
     // lv_tick_inc(now - lv_last_tick);
     // lv_last_tick = now;
     // Update the UI
-    lv_timer_handler();
-    vTaskDelay(pdMS_TO_TICKS(5));
+    // Sleep only until LVGL next needs to run, clamped to [1,5]ms so the BLE/Waveshare/IDLE
+    // tasks always get CPU time. The upper clamp also covers LV_NO_TIMER_READY (UINT32_MAX).
+    uint32_t lv_idle_ms = lv_timer_handler(); // ; was: lv_timer_handler() + fixed vTaskDelay(5)
+    if (lv_idle_ms > 5)
+        lv_idle_ms = 5;
+    else if (lv_idle_ms < 1)
+        lv_idle_ms = 1;
+    vTaskDelay(pdMS_TO_TICKS(lv_idle_ms));
 }

--- a/Wireless_Controller/src/tasks/tasks.cpp
+++ b/Wireless_Controller/src/tasks/tasks.cpp
@@ -43,13 +43,16 @@ void task_waveshare(void *parameters)
 // static StaticTask_t myTaskBuffer;
 void setup_tasks()
 {
+    // Priority 5: still above the Arduino loop task (priority 1, runs LVGL rendering) but no
+    // longer starves it. NimBLE's own host task handles the radio-critical work separately;
+    // these app loops just poll with 10ms sleeps.
     //  Bluetooth Task
     xTaskCreate(
         task_bluetooth,
         "Bluetooth",
         BLE_TASK_STACK_SIZE,
         NULL,
-        24,
+        5, // ; was: 24
         NULL);
 
     //  Waveshare board/button Task
@@ -58,7 +61,7 @@ void setup_tasks()
         "Waveshare",
         512 * 6,
         NULL,
-        24,
+        5, // ; was: 24
         NULL);
 
 


### PR DESCRIPTION
Used claude fable 5 to do a deep analysis on our architecture.
ws2p8 now achieves 30FPS with temporary drops to 26FPS at idle, and drops to as low as 18FPS on scrolling

Claude says:
The recurring root bug: in LVGL 9, sizeof(lv_color_t) is 3 bytes even with 16-bit color. Four of the five board drivers used it to size RGB565 buffers, producing mismatched or oversized buffers everywhere — including telling LVGL the ws2p8 buffer was 3× larger than allocated, which is almost certainly why partial rendering "crashed" historically and was abandoned for slow full-frame mode.

The commits, each independently revertible:

1. FPS overlay (dev-only) — LV_USE_PERF_MONITOR/SYSMON/OBSERVER enabled when OFFICIAL_RELEASE isn't defined, so you can measure everything below. Compiles out of releases (release binary is 31.9 KB smaller, confirming).
2. Global quick wins — real -O2 (the framework appends its own -Os after user flags, so I had to add build_unflags = -Os; sizes grew ~130 KB/env, worst case 70.8% of the 4 MB OTA slot), release log level INFO→WARN, packet.dump() made dev-only and the auth-loop "." spam removed, BLE/Waveshare task priority 24→5 (they were preempting the priority-1 loop task that does all rendering), and the main loop now sleeps for lv_timer_handler()'s reported idle time clamped to 1–5 ms instead of a fixed 5 ms.
3. ws2p8 (the big one) — was rendering the full 153.6 KB frame into PSRAM and pushing all of it through blocking, non-DMA Arduino SPI (>15 ms wire time) every refresh, even for a 1-px change. Now: PARTIAL mode with two correctly-sized 40-line buffers in internal DMA RAM.
4. ws3p5 — removed a per-pixel color-correction LUT whose parameters were all 1.0 (a mathematical no-op burning CPU on every flush), and shrank buffers from 460.8 KB (which made the internal-DMA fast path silently impossible) to 38.4 KB so it actually engages. Frees ~900 KB PSRAM.
5. ws2p8b — honest buffer units + 16 ms refresh override (60 FPS target; the RGB panel self-refreshes so LVGL only blits dirty strips).
6. ws3p5b — documentation only (no bench hardware per your answer): frame-skip stays off, with instructions for enabling and what to test. Its ~20 FPS ceiling is the 307 KB full-frame QSPI transfer; that needs on-device work later.
7. ws1p8knob — buffers moved internal-RAM-first (skips per-flush cache sync), plus a latent bug fix: the 3-byte sizing let LVGL produce 36-row flushes against an SPI max_transfer_sz configured for 24 rows.

Also changes refresh rate on 2.8 from 30fps to 60fps