### PR TITLE
Restructured memory on ws2p8b

### DIFF
--- a/Wireless_Controller/include/lv_conf.h
+++ b/Wireless_Controller/include/lv_conf.h
@@ -65,8 +65,17 @@
     #define LV_MEM_ADR 0     /*0: unused*/
     /*Instead of an address give a memory allocator that will be called to get a memory pool for LVGL. E.g. my_malloc*/
     #if LV_MEM_ADR == 0
-        #undef LV_MEM_POOL_INCLUDE
-        #undef LV_MEM_POOL_ALLOC
+        #ifdef LV_MEM_POOL_PSRAM
+            /* RGB-panel boards (e.g. ws2p8b) define LV_MEM_POOL_PSRAM so LVGL's builtin pool is
+             * created once in external PSRAM instead of internal RAM. This keeps the (large) UI
+             * allocations off the internal heap, leaving it free for the BLE stack to allocate on
+             * connect. Pair with a larger LV_MEM_SIZE since PSRAM has room to spare. */
+            #define LV_MEM_POOL_INCLUDE "esp_heap_caps.h"
+            #define LV_MEM_POOL_ALLOC(size) heap_caps_malloc(size, MALLOC_CAP_SPIRAM)
+        #else
+            #undef LV_MEM_POOL_INCLUDE
+            #undef LV_MEM_POOL_ALLOC
+        #endif
     #endif
 #endif  /*LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN*/
 

--- a/Wireless_Controller/platformio.ini
+++ b/Wireless_Controller/platformio.ini
@@ -96,8 +96,11 @@ build_flags = ${env.build_flags}
     '-D FIRMWARE_RELEASE_NAME="controller_ws2p8b"'
     '-D CONFIG_BT_NIMBLE_MEM_ALLOC_MODE_EXTERNAL=1' ; Fix malloc error in Nim-BLE by making it use the SPIRAM
     '-D OTA_SUPPORTED'
-    ; Use system heap for LVGL on RGB panel boards to avoid exhausting LVGL's fixed internal pool
-    '-D LV_USE_STDLIB_MALLOC=LV_STDLIB_CLIB'
+    ; RGB panel board: keep LVGL's builtin pool (so internal RAM stays free for BLE on connect),
+    ; but place that pool in PSRAM and enlarge it so the 480x640 UI doesn't exhaust it (blank screen).
+    ; ; was: '-D LV_USE_STDLIB_MALLOC=LV_STDLIB_CLIB' (system malloc starved internal RAM -> BLE malloc error)
+    '-D LV_MEM_POOL_PSRAM'
+    '-D LV_MEM_SIZE=(512U*1024U)'
 lib_deps = ${env.lib_deps}
     ./device_libs/ws2p8b
 


### PR DESCRIPTION
1. ws2p8b had lv malloc set to CLIB (standard malloc() function), so removed that and now have it set back to BUILTIN (finds space in LV_MEM_SIZE array instead of malloc) like the other devices
2. Then defined LV_MEM_POOL_ALLOC via the new LV_MEM_POOL_PSRAM flag so that the alloc for BUILTIN will alloc within psram (heap_caps_malloc(size, MALLOC_CAP_SPIRAM))
3. now that the builtin mallocs are in psram which has more memory, increase mem size to 512