### PR TITLE
2 small bugs hotfix

### DIFF
--- a/ESP32_SHARED_LIBS/src/BTOas.cpp
+++ b/ESP32_SHARED_LIBS/src/BTOas.cpp
@@ -168,7 +168,7 @@ bool BooleanPacket::getBoolean()
     return this->args32()[0].i != 0;
 }
 
-ConfigValuesPacket::ConfigValuesPacket(bool setValues, uint8_t bagMaxPressure, uint32_t systemShutoffTimeM, uint8_t compressorOnPSI, uint8_t compressorOffPSI, uint16_t pressureSensorMax, uint16_t bagVolumePercentage, uint8_t rfButtonA, uint8_t rfButtonB, uint8_t rfButtonC, uint8_t rfButtonD, uint8_t AirUpBagStretchTriggerBelowPressure, uint8_t AirUpBagStretchPressure, uint8_t compressorCrankOffset, uint32_t configFlagsBits, AuxillaryOutputModePayload auxillaryOutputConfig)
+ConfigValuesPacket::ConfigValuesPacket(bool setValues, uint8_t bagMaxPressure, uint32_t systemShutoffTimeM, uint8_t compressorOnPSI, uint8_t compressorOffPSI, uint16_t pressureSensorMax, uint8_t rfButtonA, uint8_t rfButtonB, uint8_t rfButtonC, uint8_t rfButtonD, uint8_t AirUpBagStretchTriggerBelowPressure, uint8_t AirUpBagStretchPressure, uint8_t compressorCrankOffset, uint32_t configFlagsBits, AuxillaryOutputModePayload auxillaryOutputConfig)
 {
     this->cmd = GETCONFIGVALUES;
     *this->_systemShutoffTimeM() = systemShutoffTimeM;
@@ -176,7 +176,6 @@ ConfigValuesPacket::ConfigValuesPacket(bool setValues, uint8_t bagMaxPressure, u
     *this->_compressorOnPSI() = compressorOnPSI;
     *this->_compressorOffPSI() = compressorOffPSI;
     *this->_pressureSensorMax() = pressureSensorMax;
-    *this->_bagVolumePercentage() = bagVolumePercentage;
     *this->_setValues() = setValues;
     *this->_rfButtonA() = rfButtonA;
     *this->_rfButtonB() = rfButtonB;
@@ -204,10 +203,11 @@ uint16_t *ConfigValuesPacket::_pressureSensorMax()
 {
     return (uint16_t *)&(this->args16()[4].i);
 }
-uint16_t *ConfigValuesPacket::_bagVolumePercentage()
-{
-    return (uint16_t *)&(this->args16()[5].i);
-}
+// args16()[5] retired (formerly bagVolumePercentage); left unused so no other field's slot moves.
+// uint16_t *ConfigValuesPacket::unused1()
+// {
+//     return (uint16_t *)&(this->args16()[5].i);
+// }
 uint8_t *ConfigValuesPacket::_bagMaxPressure()
 {
     return (uint8_t *)&(this->args8()[12 + 0].i);

--- a/ESP32_SHARED_LIBS/src/BTOas.h
+++ b/ESP32_SHARED_LIBS/src/BTOas.h
@@ -256,14 +256,13 @@ struct StartwebPacket : BTOasPacket
 };
 struct ConfigValuesPacket : BTOasPacket
 {
-    ConfigValuesPacket(bool setValues, uint8_t bagMaxPressure, uint32_t systemShutoffTimeM, uint8_t compressorOnPSI, uint8_t compressorOffPSI, uint16_t pressureSensorMax, uint16_t bagVolumePercentage, uint8_t rfButtonA, uint8_t rfButtonB, uint8_t rfButtonC, uint8_t rfButtonD, uint8_t AirUpBagStretchTriggerBelowPressure, uint8_t AirUpBagStretchPressure, uint8_t compressorCrankOffset, uint32_t configFlagsBits, AuxillaryOutputModePayload auxillaryOutputConfig);
+    ConfigValuesPacket(bool setValues, uint8_t bagMaxPressure, uint32_t systemShutoffTimeM, uint8_t compressorOnPSI, uint8_t compressorOffPSI, uint16_t pressureSensorMax, uint8_t rfButtonA, uint8_t rfButtonB, uint8_t rfButtonC, uint8_t rfButtonD, uint8_t AirUpBagStretchTriggerBelowPressure, uint8_t AirUpBagStretchPressure, uint8_t compressorCrankOffset, uint32_t configFlagsBits, AuxillaryOutputModePayload auxillaryOutputConfig);
     bool *_setValues();
     uint8_t *_bagMaxPressure();
     uint32_t *_systemShutoffTimeM();
     uint8_t *_compressorOnPSI();
     uint8_t *_compressorOffPSI();
     uint16_t *_pressureSensorMax();
-    uint16_t *_bagVolumePercentage();
     uint8_t *_rfButtonA(); // these rf buttons are special because we only send them with this packet (send from manifold to controller), we do not save them upon receiving them. We use RfCommandPacket to set them. It made more sense to me to just have them here instead of creating another packet for sending them from the manifold to the controller on connect. And I decided to not move the other values here because they are commands not necessarily config data being set. So essentially the other function is how we send/set the commands, and this function is how we grab the values
     uint8_t *_rfButtonB();
     uint8_t *_rfButtonC();

--- a/ESP32_SHARED_LIBS/src/directdownload.cpp
+++ b/ESP32_SHARED_LIBS/src/directdownload.cpp
@@ -1,6 +1,11 @@
 #include "directdownload.h"
 
-#ifndef RELEASE_TAG_NAME
+// PlatformIO release envs pass -D RELEASE_TAG_NAME=${sysenv.release_tag_name}.
+// When that env var is unset, the macro is defined but empty — treat like missing.
+#define RELEASE_TAG_NAME_EMPTY_HELPER(x) x##1
+#define RELEASE_TAG_NAME_IS_EMPTY(x) RELEASE_TAG_NAME_EMPTY_HELPER(x)
+#if !defined(RELEASE_TAG_NAME) || (RELEASE_TAG_NAME_IS_EMPTY(RELEASE_TAG_NAME) == 1)
+#undef RELEASE_TAG_NAME
 #define RELEASE_TAG_NAME build-dev
 #endif
 

--- a/ESP32_SHARED_LIBS/src/oasman-ota_worker.js
+++ b/ESP32_SHARED_LIBS/src/oasman-ota_worker.js
@@ -1,8 +1,9 @@
 /**
  * OASMan unified OTA worker
  * GET ?firmware=<FIRMWARE_RELEASE_NAME>&tag=<RELEASE_TAG_NAME>
- * - 204 if latest release tag matches tag (already up to date)
+ * - 204 if newest release (for that firmware) tag matches tag (already up to date)
  * - 200 + firmware binary if a newer release is available
+ * - blank/missing tag is treated as outdated (serve the newest matching binary)
  * Deploy as: oasman-ota → http://oasman-ota.gopro2027.workers.dev/
  */
 
@@ -276,10 +277,14 @@ export default {
     if (tag && tag.startsWith('"') && tag.endsWith('"')) {
       tag = tag.slice(1, -1);
     }
+    // Blank tag (test/release builds with empty sysenv.release_tag_name) = outdated.
+    if (tag == null) {
+      tag = '';
+    }
 
-    if (!firmware || !tag) {
+    if (!firmware) {
       return new Response(
-        JSON.stringify({ error: 'Missing required query params: firmware, tag' }),
+        JSON.stringify({ error: 'Missing required query param: firmware' }),
         { status: 400, headers: { 'Content-Type': 'application/json' } }
       );
     }

--- a/MobileApp/oasman_mobile/lib/ble_manager.dart
+++ b/MobileApp/oasman_mobile/lib/ble_manager.dart
@@ -204,7 +204,6 @@ class BLEManager extends ChangeNotifier {
   int compressorOffPSI = 0;
   int systemShutoffTimeM = 15;
   int pressureSensorMax = 0;
-  int bagVolumePercentage = 0;
   int bagMaxPressure = 0;
   int AirUpBagStretchTriggerBelowPressure = 0;
   int AirUpBagStretchPressure = 0;
@@ -740,7 +739,6 @@ class BLEManager extends ChangeNotifier {
           systemShutoffTimeM = _decodeInt32(data, 4); // args32()[0]
           final configFlagsBits = _decodeInt32(data, 8); // args32()[1]
           pressureSensorMax = _decodeShort(data, 12); // args16()[4]
-          bagVolumePercentage = _decodeShort(data, 14); // args16()[5]
           bagMaxPressure = data[16];
           compressorOnPSI = data[17];
           compressorOffPSI = data[18];
@@ -955,7 +953,6 @@ class BLEManager extends ChangeNotifier {
     _writeInt32Le(args, 0, systemShutoffTimeM);
     _writeInt32Le(args, 4, _buildConfigFlagsBits());
     _writeUint16Le(args, 8, pressureSensorMax);
-    _writeUint16Le(args, 10, bagVolumePercentage);
     args[12] = bagMaxPressure;
     args[13] = compressorOnPSI;
     args[14] = compressorOffPSI;

--- a/MobileApp/oasman_mobile/lib/pages/setup.dart
+++ b/MobileApp/oasman_mobile/lib/pages/setup.dart
@@ -74,7 +74,6 @@ class SettingsPageState extends State<SettingsPage> {
   late TextEditingController maxPressureController;
   late TextEditingController bagMaxController;
   late TextEditingController pressureSensorRatingController;
-  late TextEditingController bagVolumeController;
   late TextEditingController compressorCrankOffsetController;
   late TextEditingController wifiSsidController;
   late TextEditingController wifiPassController;
@@ -107,7 +106,6 @@ class SettingsPageState extends State<SettingsPage> {
     }
     bagMaxController.text = bm.bagMaxPressure.toString();
     pressureSensorRatingController.text = bm.pressureSensorMax.toString();
-    bagVolumeController.text = bm.bagVolumePercentage.toString();
     compressorCrankOffsetController.text = bm.compressorCrankOffset.toString();
     auxPulseDurationController.text = bm.auxPulseDuration.toString();
     auxIntervalCyclesController.text = bm.auxIntervalCycles.toString();
@@ -126,7 +124,6 @@ class SettingsPageState extends State<SettingsPage> {
     maxPressureController.dispose();
     bagMaxController.dispose();
     pressureSensorRatingController.dispose();
-    bagVolumeController.dispose();
     compressorCrankOffsetController.dispose();
     wifiSsidController.dispose();
     wifiPassController.dispose();
@@ -226,10 +223,6 @@ class SettingsPageState extends State<SettingsPage> {
       final psMax = int.tryParse(pressureSensorRatingController.text.trim());
       if (psMax != null) {
         bm.pressureSensorMax = psMax.clamp(0, 65535);
-      }
-      final bagVol = int.tryParse(bagVolumeController.text.trim());
-      if (bagVol != null) {
-        bm.bagVolumePercentage = bagVol.clamp(10, 600);
       }
       final crankOffset =
           int.tryParse(compressorCrankOffsetController.text.trim());
@@ -475,7 +468,6 @@ class SettingsPageState extends State<SettingsPage> {
     maxPressureController = TextEditingController();
     bagMaxController = TextEditingController();
     pressureSensorRatingController = TextEditingController();
-    bagVolumeController = TextEditingController();
     compressorCrankOffsetController = TextEditingController();
     wifiSsidController =
         TextEditingController(text: prefs.getString('_wifiSsid') ?? '');
@@ -496,7 +488,6 @@ class SettingsPageState extends State<SettingsPage> {
       _lastSyncedConfigRevision = bm.configRevision;
       bagMaxController.text = bm.bagMaxPressure.toString();
       pressureSensorRatingController.text = bm.pressureSensorMax.toString();
-      bagVolumeController.text = bm.bagVolumePercentage.toString();
       compressorCrankOffsetController.text = bm.compressorCrankOffset.toString();
       print("Manifold's settings loaded");
     }
@@ -1021,16 +1012,6 @@ class SettingsPageState extends State<SettingsPage> {
                                   tooltipTitle: 'Pressure Sensor Rating PSI',
                                   tooltip:
                                       'Rated range of your pressure sensors. Must match manifold configuration.',
-                                  saveWhenKeyboardDone: true,
-                                ),
-                                _buildKeyboardInputRow(
-                                  'Bag Volume Percentage',
-                                  bagVolumeController,
-                                  isNumberInput: true,
-                                  limitChar: 3,
-                                  tooltipTitle: 'Bag Volume Percentage',
-                                  tooltip:
-                                      'Bag volume factor (10–600). Matches the wireless controller slider range.',
                                   saveWhenKeyboardDone: true,
                                 ),
                               ],

--- a/OASMan_ESP32/BLE_API_DOCUMENTATION.md
+++ b/OASMan_ESP32/BLE_API_DOCUMENTATION.md
@@ -476,7 +476,7 @@ StartwebPacket packet("MyWiFi", "password123");
 - `args32()[0]`: `uint32_t systemShutoffTimeM` - System shutoff time in minutes
 - `args32()[1]`: `uint32_t configFlagsBits` - User config flags (see ConfigFlagsBit enum)
 - `args16()[4]`: `uint16_t pressureSensorMax` - Maximum pressure sensor value
-- `args16()[5]`: `uint16_t bagVolumePercentage` - Bag volume percentage
+- `args16()[5]`: _retired_ (formerly `bagVolumePercentage`) 
 - `args8()[12+0]`: `uint8_t bagMaxPressure` - Maximum bag pressure
 - `args8()[12+1]`: `uint8_t compressorOnPSI` - Compressor turn-on PSI
 - `args8()[12+2]`: `uint8_t compressorOffPSI` - Compressor turn-off PSI

--- a/OASMan_ESP32/src/bluetooth/ble.cpp
+++ b/OASMan_ESP32/src/bluetooth/ble.cpp
@@ -532,7 +532,7 @@ ConfigValuesPacket buildCurrentConfigValuesPacket()
     auxillaryOutputConfig.timeUnit = (AuxillaryOutputModeTimeUnit)getauxillaryOutputModeTimeUnit();
     auxillaryOutputConfig.time = getauxillaryOutputTime();
     auxillaryOutputConfig.interval = getauxillaryOutputInterval();
-    return ConfigValuesPacket(false, getbagMaxPressure(), getsystemShutoffTimeM(), getcompressorOnPSI(), getcompressorOffPSI(), getpressureSensorMax(), getbagVolumePercentage(), getrfButtonAPreset(), getrfButtonBPreset(), getrfButtonCPreset(), getrfButtonDPreset(), getAirUpBagStretchTriggerBelowPressure(), getAirUpBagStretchPressure(), getcompressorCrankOffset(), configFlagsBits, auxillaryOutputConfig);
+    return ConfigValuesPacket(false, getbagMaxPressure(), getsystemShutoffTimeM(), getcompressorOnPSI(), getcompressorOffPSI(), getpressureSensorMax(), getrfButtonAPreset(), getrfButtonBPreset(), getrfButtonCPreset(), getrfButtonDPreset(), getAirUpBagStretchTriggerBelowPressure(), getAirUpBagStretchPressure(), getcompressorCrankOffset(), configFlagsBits, auxillaryOutputConfig);
 }
 
 void ble_notify()
@@ -694,7 +694,6 @@ void runReceivedPacket(hci_con_handle_t con_handle, BTOasPacket *packet)
             setcompressorOnPSI(*recpkt->_compressorOnPSI());
             setcompressorOffPSI(*recpkt->_compressorOffPSI());
             setpressureSensorMax(*recpkt->_pressureSensorMax());
-            setbagVolumePercentage(*recpkt->_bagVolumePercentage());
             setAirUpBagStretchTriggerBelowPressure(*recpkt->_AirUpBagStretchTriggerBelowPressure());
             setAirUpBagStretchPressure(*recpkt->_AirUpBagStretchPressure());
             setcompressorCrankOffset(*recpkt->_compressorCrankOffset());

--- a/OASMan_ESP32/src/manifoldSaveData.cpp
+++ b/OASMan_ESP32/src/manifoldSaveData.cpp
@@ -58,7 +58,6 @@ void beginSaveData()
     _SaveData.compressorOffPSI.load("compressorOffPSI", COMPRESSOR_MAX_PSI);
     _SaveData.compressorCrankOffset.load("compCrankOff", COMPRESSOR_CRANK_OFFSET_S); // key kept under 15 chars (Preferencable::name limit)
     _SaveData.pressureSensorMax.load("pressureSensorMax", pressuretransducermaxPSI);
-    _SaveData.bagVolumePercentage.load("bagVolumePercentage", 100);
     _SaveData.AirUpBagStretchTriggerBelowPressure.load("bagStretchTrig", 40); // if bag is currently below 40 psi...
     _SaveData.AirUpBagStretchPressure.load("bagStretchPsi", 0); // go to this pressure to stretch bag out first
 
@@ -141,7 +140,6 @@ createSaveFuncInt(compressorOnPSI, uint8_t);
 createSaveFuncInt(compressorOffPSI, uint8_t);
 createSaveFuncInt(compressorCrankOffset, uint8_t);
 createSaveFuncInt(pressureSensorMax, uint16_t);
-createSaveFuncInt(bagVolumePercentage, uint16_t);
 createSaveFuncInt(AirUpBagStretchTriggerBelowPressure, uint8_t);
 createSaveFuncInt(AirUpBagStretchPressure, uint8_t);
 

--- a/OASMan_ESP32/src/manifoldSaveData.h
+++ b/OASMan_ESP32/src/manifoldSaveData.h
@@ -72,7 +72,6 @@ public:
     Preferencable compressorOffPSI;
     Preferencable compressorCrankOffset;
     Preferencable pressureSensorMax;
-    Preferencable bagVolumePercentage;
     Preferencable AirUpBagStretchTriggerBelowPressure;
     Preferencable AirUpBagStretchPressure;
 
@@ -135,7 +134,6 @@ headerDefineSaveFunc(compressorOnPSI, uint8_t);
 headerDefineSaveFunc(compressorOffPSI, uint8_t);
 headerDefineSaveFunc(compressorCrankOffset, uint8_t); // seconds to hold the compressor off after power up / accessory power
 headerDefineSaveFunc(pressureSensorMax, uint16_t);
-headerDefineSaveFunc(bagVolumePercentage, uint16_t);
 headerDefineSaveFunc(AirUpBagStretchTriggerBelowPressure, uint8_t);
 headerDefineSaveFunc(AirUpBagStretchPressure, uint8_t);
 

--- a/Wireless_Controller/src/ui/components/option.cpp
+++ b/Wireless_Controller/src/ui/components/option.cpp
@@ -43,6 +43,34 @@ void Option::resetHeaderStyle()
     styleCreated = false;
 }
 
+// Rows are not scroll containers, so content taller than the row is clipped with no way to reveal
+// it. Grow this one row instead when something in it needs more than the standard row height.
+void Option::growRowHeightTo(int neededHeight)
+{
+    if (this->root == NULL || neededHeight <= this->optionRowHeight)
+        return;
+    this->optionRowHeight = neededHeight;
+    lv_obj_set_height(this->root, this->optionRowHeight);
+}
+
+// Option types that constrain their label's width (so the value widget has room on the right) let a
+// long name wrap onto extra lines, which can be taller than the standard row. `labelWidth` is the
+// width the label was given, ie what the text wraps against.
+void Option::fitHeightToWrappedLabel(int labelWidth)
+{
+    if (this->text == NULL || labelWidth <= 0)
+        return;
+
+    lv_point_t textSize;
+    lv_text_get_size(&textSize, lv_label_get_text(this->text),
+                     lv_obj_get_style_text_font(this->text, LV_PART_MAIN),
+                     lv_obj_get_style_text_letter_space(this->text, LV_PART_MAIN),
+                     lv_obj_get_style_text_line_space(this->text, LV_PART_MAIN),
+                     labelWidth, LV_TEXT_FLAG_NONE);
+
+    this->growRowHeightTo(textSize.y + scaledY(8)); // breathing room above/below the text
+}
+
 void Option::styleDropdownClosed(lv_obj_t *dd)
 {
     lv_obj_set_style_bg_color(dd, lv_color_hex(0x161A1F), LV_PART_MAIN);
@@ -200,6 +228,12 @@ Option::Option(lv_obj_t *parent, OptionType type, const char *text, OptionValue 
     createStyle();
     this->root = lv_obj_create(parent);
     lv_obj_remove_style_all(this->root);
+    // A settings row is a fixed-size holder, never a scroll container. Left scrollable (the
+    // lv_obj_create default) a row whose content is taller than it - eg a long option name that
+    // wraps to three lines - would scroll its own content on drag instead of passing the gesture up
+    // to the settings page. findVScrollAncestor() in util.cpp (keyboard-open scrolling) also relies
+    // on rows never being a vertical scroll container.
+    lv_obj_remove_flag(this->root, LV_OBJ_FLAG_SCROLLABLE);
 #ifdef SCREEN_MODE_CIRCLE
     lv_obj_set_size(this->root, LV_PCT(100), this->optionRowHeight);
 #else
@@ -314,6 +348,7 @@ Option::Option(lv_obj_t *parent, OptionType type, const char *text, OptionValue 
         const int textAreaWidth = (type == OptionType::KEYBOARD_INPUT_TEXT) ? scaledX(150) : scaledX(70);
         const int textMaxWidth = getScreenWidth() - (MARGIN * 2 + MARGIN + textAreaWidth) - scaledX(6);
         lv_obj_set_width(this->text, textMaxWidth); // space between the start position and the text input
+        this->fitHeightToWrappedLabel(textMaxWidth);
 
         this->rightHandObj = lv_textarea_create(this->root);
         lv_textarea_set_text(this->rightHandObj, (type == OptionType::KEYBOARD_INPUT_TEXT) ? value.STRING : itoa(value.INT, strbuf, 10));
@@ -356,15 +391,20 @@ Option::Option(lv_obj_t *parent, OptionType type, const char *text, OptionValue 
         const int ddLogicalW = (getScreenWidth() * 52) / 100;
         const int textMaxWidth = getScreenWidth() - (MARGIN * 2 + MARGIN + ddLogicalW) - scaledX(6);
         lv_obj_set_width(this->text, textMaxWidth);
+        this->fitHeightToWrappedLabel(textMaxWidth);
 
         this->rightHandObj = lv_dropdown_create(this->root);
         lv_dropdown_set_options(this->rightHandObj, ddOptions != NULL ? ddOptions : "");
         lv_obj_set_width(this->rightHandObj, LV_PCT(52));
 #ifdef SCREEN_MODE_CIRCLE
-        lv_obj_set_height(this->rightHandObj, scaledY(32));
+        const int ddHeight = scaledY(32);
 #else
-        lv_obj_set_height(this->rightHandObj, scaledY(36));
+        const int ddHeight = scaledY(36);
 #endif
+        lv_obj_set_height(this->rightHandObj, ddHeight);
+        // On panels where the row is short relative to scaledY (eg ws3p5) the dropdown is taller
+        // than the standard row; the row has to grow to hold it since it cannot scroll.
+        this->growRowHeightTo(ddHeight + scaledY(6));
         lv_obj_set_align(this->rightHandObj, LV_ALIGN_RIGHT_MID);
         lv_obj_set_x(this->rightHandObj, -MARGIN);
         lv_obj_set_y(this->rightHandObj, 0);

--- a/Wireless_Controller/src/ui/components/option.h
+++ b/Wireless_Controller/src/ui/components/option.h
@@ -71,6 +71,8 @@ public:
     static void styleDropdownClosed(lv_obj_t *dd);
     static void styleDropdownList(lv_obj_t *dd);
     void setBooleanValue(bool value, bool netSend = false);
+    void growRowHeightTo(int neededHeight);
+    void fitHeightToWrappedLabel(int labelWidth);
     void indentText(int extraX = 0);
     static void resetHeaderStyle();
 };

--- a/Wireless_Controller/src/ui/screens/ui_scrSettings.cpp
+++ b/Wireless_Controller/src/ui/screens/ui_scrSettings.cpp
@@ -833,15 +833,6 @@ void ScrSettings::init(lv_obj_t *parent)
         alertValueUpdated();
     });
 
-    this->ui_config6 = new Option(config_page, OptionType::SLIDER, "Bag Volume Percentage", {.INT = 100}, [](void *data)
-    {
-        log_i("Pressed %i", ((uint32_t)data));
-        *util_configValues._bagVolumePercentage() = (uint32_t)data;
-        sendConfigValuesPacket(true);
-        alertValueUpdated();
-    });
-    ((Option *)this->ui_config6)->setSliderParams(10, 600, true, LV_EVENT_RELEASED);
-
     this->ui_config7 = new Option(config_page, OptionType::KEYBOARD_INPUT_NUMBER, "Bag Stretch Below PSI", {.INT = 0}, [](void *data)
     {
         log_i("Pressed %i", ((uint32_t)data));
@@ -1139,7 +1130,6 @@ void ScrSettings::loop()
         this->ui_config3->setRightHandText(itoa(*util_configValues._compressorOnPSI(), buf, 10));
         this->ui_config4->setRightHandText(itoa(*util_configValues._compressorOffPSI(), buf, 10));
         this->ui_config5->setRightHandText(itoa(*util_configValues._pressureSensorMax(), buf, 10));
-        this->ui_config6->setRightHandText(itoa(*util_configValues._bagVolumePercentage(), buf, 10));
         this->ui_config7->setRightHandText(itoa(*util_configValues._AirUpBagStretchTriggerBelowPressure(), buf, 10));
         this->ui_config8->setRightHandText(itoa(*util_configValues._AirUpBagStretchPressure(), buf, 10));
         this->ui_config9->setRightHandText(itoa(*util_configValues._compressorCrankOffset(), buf, 10));
@@ -1212,7 +1202,6 @@ void ScrSettings::cleanup()
     delete ui_config3;
     delete ui_config4;
     delete ui_config5;
-    delete ui_config6;
     delete ui_config7;
     delete ui_config8;
     delete ui_config9;

--- a/Wireless_Controller/src/ui/screens/ui_scrSettings.h
+++ b/Wireless_Controller/src/ui/screens/ui_scrSettings.h
@@ -53,7 +53,6 @@ public:
     Option *ui_config3;  // Compressor On PSI (textarea)
     Option *ui_config4;  // Compressor Off PSI (textarea)
     Option *ui_config5;  // Pressure Sensor Rating PSI (textarea)
-    Option *ui_config6;  // Bag Volume Percentage (slider)
     Option *ui_config7;  // Bag Stretch Below PSI (textarea)
     Option *ui_config8;  // Bag Stretch PSI (textarea)
     Option *ui_config9;  // Compressor Crank Offset seconds (textarea)

--- a/Wireless_Controller/src/utils/util.cpp
+++ b/Wireless_Controller/src/utils/util.cpp
@@ -89,7 +89,7 @@ void requestPreset()
     sendRestPacket(&pkt);
 }
 
-ConfigValuesPacket util_configValues(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+ConfigValuesPacket util_configValues(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     {AUX_MODE_NONE, AUX_MODE_TIME_DECISECONDS, 1, 0});
 
 void sendConfigValuesPacket(bool saveToManifold)


### PR DESCRIPTION
for 1.3.0, i introduced 2 bugs.
1. scrolling on compressor crank offset row
2. now unused feature 'bag volume percentage' was not removed.

fixed both of them
also fixed the issue with ota on production releases manifold not generated with a version number (ie compiled locally for use on a board).