### PR TITLE
Fix BLE notify task deadlock after unclean client disconnect

### DIFF
--- a/OASMan_ESP32/src/bluetooth/ble.cpp
+++ b/OASMan_ESP32/src/bluetooth/ble.cpp
@@ -605,12 +605,12 @@ void ble_notify()
         memcpy(rest_characteristic_data, packet.tx(), BTOAS_PACKET_SIZE);
         uint8_t res = att_server_notify_SAFE(rest_con_handle, rest_characteristic_value_handle, rest_characteristic_data, BTOAS_PACKET_SIZE);
         if (res == ERROR_CODE_CONNECTION_TIMEOUT) {
-            Serial.println("Connection timeout, dropping packets for this connection!");
+            //Serial.println("Connection timeout, dropping packets for this connection!");
             packetMover::clearPacketsForHandle(rest_con_handle); // clear here so it doesn't get stuck waiting 500ms for every packet in att_server_notify_SAFE
         } else if (res == ERROR_CODE_SUCCESS) {
-            Serial.println("Sent rest packet!");
+            //Serial.println("Sent rest packet!");
         } else {
-            Serial.println("Error sending rest packet!");
+            //Serial.println("Error sending rest packet!");
         }
         delay(40);
     }

--- a/OASMan_ESP32/src/bluetooth/ble.cpp
+++ b/OASMan_ESP32/src/bluetooth/ble.cpp
@@ -606,7 +606,7 @@ void ble_notify()
         uint8_t res = att_server_notify_SAFE(rest_con_handle, rest_characteristic_value_handle, rest_characteristic_data, BTOAS_PACKET_SIZE);
         if (res == ERROR_CODE_CONNECTION_TIMEOUT) {
             Serial.println("Connection timeout, dropping packets for this connection!");
-            packetMover::clearPacketsForHandle(rest_con_handle);
+            packetMover::clearPacketsForHandle(rest_con_handle); // clear here so it doesn't get stuck waiting 500ms for every packet in att_server_notify_SAFE
         } else if (res == ERROR_CODE_SUCCESS) {
             Serial.println("Sent rest packet!");
         } else {

--- a/OASMan_ESP32/src/bluetooth/ble.cpp
+++ b/OASMan_ESP32/src/bluetooth/ble.cpp
@@ -563,7 +563,7 @@ uint8_t att_server_notify_SAFE(hci_con_handle_t con_handle, uint16_t attribute_h
         }
         delay(5);
     }
-    return att_server_notify(con_handle, attribute_handle, value, value_len); // returns ERROR_CODE_SUCCESS on success
+    return att_server_notify(con_handle, attribute_handle, value, value_len);
 }
 
 ConfigValuesPacket buildCurrentConfigValuesPacket()

--- a/OASMan_ESP32/src/bluetooth/ble.cpp
+++ b/OASMan_ESP32/src/bluetooth/ble.cpp
@@ -78,6 +78,19 @@ namespace packetMover
         giveRestSemaphore();
     }
 
+    void clearPacketsForHandle(hci_con_handle_t con_handle)
+    {
+        waitRestSemaphore();
+        for (int i = 0; i < BTOASPACKETCOUNT; i++)
+        {
+            if (packets[i].taken && packets[i].con_handle == con_handle)
+            {
+                packets[i].taken = false;
+            }
+        }
+        giveRestSemaphore();
+    }
+
 };
 
 #pragma endregion
@@ -536,11 +549,19 @@ void ble_loop()
 
 uint8_t att_server_notify_SAFE(hci_con_handle_t con_handle, uint16_t attribute_handle, const uint8_t *value, uint16_t value_len)
 {
-
+    // For a dropped connection att_server_can_send_packet_now() is false
+    // forever; without a deadline this would wedge the task and stall the
+    // notify/auth path for every other client.
+    const unsigned long start = millis();
+    const unsigned long timeoutMs = 250;
     while (!att_server_can_send_packet_now(con_handle))
     {
-        // log_i("\n\n\nCAN'T SEND PACKET\n\n\n");
-        delay(10);
+        if (millis() - start >= timeoutMs)
+        {
+            packetMover::clearPacketsForHandle(con_handle);
+            return ERROR_CODE_UNKNOWN_CONNECTION_IDENTIFIER;
+        }
+        delay(5);
     }
     return att_server_notify(con_handle, attribute_handle, value, value_len);
 }

--- a/OASMan_ESP32/src/bluetooth/ble.cpp
+++ b/OASMan_ESP32/src/bluetooth/ble.cpp
@@ -439,13 +439,8 @@ static void hci_event_handler(uint8_t packet_type, uint16_t channel, uint8_t *pa
         {
             hci_con_handle_t disconnected = hci_event_disconnection_complete_get_connection_handle(packet);
             removeAuthed(disconnected);
-            // Drop any responses still queued for the dead handle. Its
-            // hci_connection is freed, so att_server_can_send_packet_now()
-            // stays false forever and ble_notify() would busy-wait on them,
-            // stalling the Bluetooth task (and the auth/notify path for
-            // every other client). The bounded wait in
-            // att_server_notify_SAFE is only the safety net for the rare
-            // dequeue/disconnect race where a packet is already in flight.
+            // A freed handle's queued responses can never be sent; clear them
+            // or ble_notify() stalls (see att_server_notify_SAFE).
             packetMover::clearPacketsForHandle(disconnected);
         }
         // don't leave a valve open because the client disconnected mid-hold
@@ -558,16 +553,10 @@ void ble_loop()
     ble_notify();
 }
 
-// Safety net only. In the normal case the packetMover queue is already
-// drained of a dropped client's packets by the DISCONNECTION_COMPLETE
-// handler, so this just sends and returns. The bounded wait below only
-// matters for the narrow race where ble_notify() has already dequeued a
-// packet for a handle that dies in the same instant: without a deadline
-// att_server_can_send_packet_now() would stay false forever (the
-// hci_connection is freed) and wedge the Bluetooth task, stalling the
-// notify/auth path for every other client. On that timeout we flush any
-// remaining packets for the dead handle and give up on this one rather
-// than block the task.
+// Bounded wait: once a connection drops, att_server_can_send_packet_now()
+// is false forever, so an unbounded loop here would wedge the Bluetooth
+// task. The DISCONNECTION handler normally clears stale packets first; this
+// deadline is the backstop for the dequeue/disconnect race.
 uint8_t att_server_notify_SAFE(hci_con_handle_t con_handle, uint16_t attribute_handle, const uint8_t *value, uint16_t value_len)
 {
     const unsigned long start = millis();

--- a/OASMan_ESP32/src/bluetooth/ble.cpp
+++ b/OASMan_ESP32/src/bluetooth/ble.cpp
@@ -436,7 +436,18 @@ static void hci_event_handler(uint8_t packet_type, uint16_t channel, uint8_t *pa
     {
     case HCI_EVENT_DISCONNECTION_COMPLETE:
         log_i("Client disconnected!");
-        removeAuthed(hci_event_disconnection_complete_get_connection_handle(packet));
+        {
+            hci_con_handle_t disconnected = hci_event_disconnection_complete_get_connection_handle(packet);
+            removeAuthed(disconnected);
+            // Drop any responses still queued for the dead handle. Its
+            // hci_connection is freed, so att_server_can_send_packet_now()
+            // stays false forever and ble_notify() would busy-wait on them,
+            // stalling the Bluetooth task (and the auth/notify path for
+            // every other client). The bounded wait in
+            // att_server_notify_SAFE is only the safety net for the rare
+            // dequeue/disconnect race where a packet is already in flight.
+            packetMover::clearPacketsForHandle(disconnected);
+        }
         // don't leave a valve open because the client disconnected mid-hold
         releaseBleHeldValves();
         gap_advertisements_enable(1);
@@ -547,11 +558,18 @@ void ble_loop()
     ble_notify();
 }
 
+// Safety net only. In the normal case the packetMover queue is already
+// drained of a dropped client's packets by the DISCONNECTION_COMPLETE
+// handler, so this just sends and returns. The bounded wait below only
+// matters for the narrow race where ble_notify() has already dequeued a
+// packet for a handle that dies in the same instant: without a deadline
+// att_server_can_send_packet_now() would stay false forever (the
+// hci_connection is freed) and wedge the Bluetooth task, stalling the
+// notify/auth path for every other client. On that timeout we flush any
+// remaining packets for the dead handle and give up on this one rather
+// than block the task.
 uint8_t att_server_notify_SAFE(hci_con_handle_t con_handle, uint16_t attribute_handle, const uint8_t *value, uint16_t value_len)
 {
-    // For a dropped connection att_server_can_send_packet_now() is false
-    // forever; without a deadline this would wedge the task and stall the
-    // notify/auth path for every other client.
     const unsigned long start = millis();
     const unsigned long timeoutMs = 250;
     while (!att_server_can_send_packet_now(con_handle))

--- a/OASMan_ESP32/src/bluetooth/ble.cpp
+++ b/OASMan_ESP32/src/bluetooth/ble.cpp
@@ -439,8 +439,6 @@ static void hci_event_handler(uint8_t packet_type, uint16_t channel, uint8_t *pa
         {
             hci_con_handle_t disconnected = hci_event_disconnection_complete_get_connection_handle(packet);
             removeAuthed(disconnected);
-            // A freed handle's queued responses can never be sent; clear them
-            // or ble_notify() stalls (see att_server_notify_SAFE).
             packetMover::clearPacketsForHandle(disconnected);
         }
         // don't leave a valve open because the client disconnected mid-hold
@@ -553,24 +551,19 @@ void ble_loop()
     ble_notify();
 }
 
-// Bounded wait: once a connection drops, att_server_can_send_packet_now()
-// is false forever, so an unbounded loop here would wedge the Bluetooth
-// task. The DISCONNECTION handler normally clears stale packets first; this
-// deadline is the backstop for the dequeue/disconnect race.
 uint8_t att_server_notify_SAFE(hci_con_handle_t con_handle, uint16_t attribute_handle, const uint8_t *value, uint16_t value_len)
 {
     const unsigned long start = millis();
-    const unsigned long timeoutMs = 250;
+    const unsigned long timeoutMs = 500;
     while (!att_server_can_send_packet_now(con_handle))
     {
         if (millis() - start >= timeoutMs)
         {
-            packetMover::clearPacketsForHandle(con_handle);
-            return ERROR_CODE_UNKNOWN_CONNECTION_IDENTIFIER;
+            return ERROR_CODE_CONNECTION_TIMEOUT;
         }
         delay(5);
     }
-    return att_server_notify(con_handle, attribute_handle, value, value_len);
+    return att_server_notify(con_handle, attribute_handle, value, value_len); // returns ERROR_CODE_SUCCESS on success
 }
 
 ConfigValuesPacket buildCurrentConfigValuesPacket()
@@ -610,8 +603,15 @@ void ble_notify()
         delay(40); // This feels really shitty but it wants some delay here in-between packets or it won't send. So there is various delay's throught this file
         packet.dump();
         memcpy(rest_characteristic_data, packet.tx(), BTOAS_PACKET_SIZE);
-        att_server_notify_SAFE(rest_con_handle, rest_characteristic_value_handle, rest_characteristic_data, BTOAS_PACKET_SIZE);
-        Serial.println("Sent rest packet!");
+        uint8_t res = att_server_notify_SAFE(rest_con_handle, rest_characteristic_value_handle, rest_characteristic_data, BTOAS_PACKET_SIZE);
+        if (res == ERROR_CODE_CONNECTION_TIMEOUT) {
+            Serial.println("Connection timeout, dropping packets for this connection!");
+            packetMover::clearPacketsForHandle(rest_con_handle);
+        } else if (res == ERROR_CODE_SUCCESS) {
+            Serial.println("Sent rest packet!");
+        } else {
+            Serial.println("Error sending rest packet!");
+        }
         delay(40);
     }
 


### PR DESCRIPTION
The in-car controller randomly refused to connect to the manifold after the web controller (oasman.co/controller) dropped without a clean UI disconnect.

packetMover queue entries are keyed by hci_con_handle_t and are independent of authedClients. On DISCONNECTION_COMPLETE only removeAuthed() ran, so queued responses for the dead handle (the web app fires a GETCONFIGVALUES + PRESET burst on connect) lingered. ble_notify() later drained one and called att_server_notify_SAFE(dead_handle, ...), which busy-waited on att_server_can_send_packet_now() -- false forever for a dropped connection -- wedging the Bluetooth task. That task also drives checkConnectedClients() and the notify path, so a reconnecting in-car controller never received AUTHRESULT_SUCCESS in time and reported 'Auth timed out'. It recovered only when a new connection reused the same handle number or the manifold was power-cycled.

- Bound the send-slot wait in att_server_notify_SAFE (250ms), dropping the packet for that handle on timeout.
- Add packetMover::clearPacketsForHandle() and call it on DISCONNECTION_COMPLETE.

Builds clean: manifold_v2_dev, manifold_v3_dev, manifold_v4_dev.