### PR TITLE
Ota rollback

### DIFF
--- a/ESP32_SHARED_LIBS/src/directdownload.cpp
+++ b/ESP32_SHARED_LIBS/src/directdownload.cpp
@@ -13,6 +13,9 @@
 #define download_firmware_response_retry 2
 #define download_firmware_response_fail -1
 
+// Only picks which status the user sees once the retries are exhausted.
+static bool lastFailureWasCorruptDownload = false;
+
 /* WiFi.status() is not enough to tell "still trying" from "we were rejected":
  * the core's STA.cpp maps 4WAY_HANDSHAKE_TIMEOUT to WL_DISCONNECTED, the same
  * value it reports mid-connect. The disconnect reason is the only place that
@@ -122,6 +125,8 @@ bool check300Redirect(int httpCode, String &responseURLString)
 
 int installFirmware(String &url)
 {
+    lastFailureWasCorruptDownload = false;
+
     if (!https->begin(url))
     {
         log_i("Connection failed");
@@ -131,8 +136,8 @@ int installFirmware(String &url)
     https->useHTTP10(true); // not necessary, but tells the server we don't support chunked responses
     https->setReuse(false); // helps with stability on flaky wifi connections. This is automatically set to true if useHTTP10 is true, but added here for clarity.
     https->setTimeout(65535); // 65535 milliseconds = 65.535 seconds = 1 minute and 5.535 seconds
-    const char *headerKeys[] = {"Content-Length"};
-    https->collectHeaders(headerKeys, 1);// may help ensure content length is stored by the HTTPClient
+    const char *headerKeys[] = {"Content-Length", OTA_FIRMWARE_MD5_HEADER};
+    https->collectHeaders(headerKeys, 2);// may help ensure content length is stored by the HTTPClient
     int httpCode = https->GET();
     log_i("HTTP GET code: %d", httpCode);
 
@@ -185,6 +190,18 @@ int installFirmware(String &url)
         return download_firmware_response_retry;
     }
 
+    // After begin(), which clears any armed digest. Optional so an older worker still works.
+    const String expectedMd5 = https->header(OTA_FIRMWARE_MD5_HEADER);
+    if (Update.setMD5(expectedMd5.c_str()))
+    {
+        log_i("Verifying firmware against MD5 %s", expectedMd5.c_str());
+    }
+    else
+    {
+        log_w("No usable %s header (got \"%s\"), installing without an integrity check",
+              OTA_FIRMWARE_MD5_HEADER, expectedMd5.c_str());
+    }
+
     size_t written = Update.writeStream(*https->getStreamPtr());
 
     if (written != (size_t)fileSize)
@@ -202,9 +219,16 @@ int installFirmware(String &url)
     {
         log_i("Update was successful!");
     }
+    else if (Update.getError() == UPDATE_ERROR_MD5)
+    {
+        // Update aborted before _verifyEnd(), so the boot partition was never switched.
+        log_i("Firmware MD5 mismatch, the download was corrupted. Retry?");
+        lastFailureWasCorruptDownload = true;
+        return download_firmware_response_retry;
+    }
     else
     {
-        log_i("Update download failed");
+        log_i("Update download failed: %s", Update.errorString());
         setupdateResult(UPDATE_STATUS::UPDATE_STATUS_FAIL_GENERIC);
         ESP.restart();
         return download_firmware_response_fail;
@@ -288,12 +312,15 @@ void downloadUpdate(String SSID, String PASS)
     log_i("Downloading firmware from %s", url.c_str());
 
     counter = 0;
+    lastFailureWasCorruptDownload = false;
     while (installFirmware(url) != download_firmware_response_success)
     {
         if (counter > 5)
         {
             log_i("Failed to download firmware after multiple attempts.");
-            setupdateResult(UPDATE_STATUS::UPDATE_STATUS_FAIL_FILE_REQUEST);
+            setupdateResult(lastFailureWasCorruptDownload
+                                ? UPDATE_STATUS::UPDATE_STATUS_FAIL_CORRUPT_DOWNLOAD
+                                : UPDATE_STATUS::UPDATE_STATUS_FAIL_FILE_REQUEST);
             ESP.restart();
             return;
         }

--- a/ESP32_SHARED_LIBS/src/directdownload.h
+++ b/ESP32_SHARED_LIBS/src/directdownload.h
@@ -25,11 +25,16 @@ enum UPDATE_STATUS
     UPDATE_STATUS_FAIL_GENERIC,
     UPDATE_STATUS_FAIL_ALREADY_UP_TO_DATE,
     UPDATE_STATUS_FAIL_WIFI_PASSWORD,
-    UPDATE_STATUS_FAIL_WIFI_NO_NETWORK
+    UPDATE_STATUS_FAIL_WIFI_NO_NETWORK,
+    // Append only. Reported to clients as strings, never as the raw byte, so this is not a wire change.
+    UPDATE_STATUS_FAIL_CORRUPT_DOWNLOAD
 };
 
 extern void setupdateResult(byte value);
 
 void downloadUpdate(String SSID, String PASS);
+
+// MD5 of the exact body the worker sent; absent from older worker deployments.
+#define OTA_FIRMWARE_MD5_HEADER "X-Firmware-MD5"
 
 #endif

--- a/ESP32_SHARED_LIBS/src/oasman-ota.wrangler.toml
+++ b/ESP32_SHARED_LIBS/src/oasman-ota.wrangler.toml
@@ -1,0 +1,14 @@
+# Deploy from the repo root: npx wrangler deploy -c ESP32_SHARED_LIBS/src/oasman-ota.wrangler.toml
+name = "oasman-ota"
+main = "oasman-ota_worker.js"
+compatibility_date = "2024-11-01"
+workers_dev = true
+keep_vars = true
+
+# Account Secrets Store token, read by the worker as env.GITHUB_TOKEN. Deploying without this removes the binding.
+secrets_store_secrets = [
+  { binding = "GITHUB_TOKEN", store_id = "fcfd9bd535d3466f98f29dabcf622dc8", secret_name = "github-cloudflare-ota-token-no-expiry" }
+]
+
+[observability]
+enabled = true

--- a/ESP32_SHARED_LIBS/src/oasman-ota_flowchart.md
+++ b/ESP32_SHARED_LIBS/src/oasman-ota_flowchart.md
@@ -15,7 +15,10 @@ flowchart TB
     subgraph esp32 [ESP32]
         A[downloadUpdate connects WiFi]
         B[installFirmware single GET]
-        C[Update.writeStream then restart]
+        C[Update.writeStream, verify MD5, restart]
+        V{Runs OTA_VERIFY_CONFIRM_MS without rebooting?}
+        OK[esp_ota_mark_app_valid_cancel_rollback]
+        RB[Bootloader boots the previous slot]
     end
 
     subgraph worker [oasman-ota Worker]
@@ -55,7 +58,14 @@ flowchart TB
     K --> R200
     R204 --> ESP204[Set ALREADY_UP_TO_DATE]
     R200 --> C
+    C --> V
+    V -->|yes| OK
+    V -->|no| RB
 ```
+
+The new image boots unconfirmed (`ESP_OTA_IMG_PENDING_VERIFY`) and is confirmed once `loop()` has
+run for `OTA_VERIFY_CONFIRM_MS` -- see [`otarollback.cpp`](./otarollback.cpp). Any reboot before
+that point is reverted by the bootloader.
 
 ---
 
@@ -79,9 +89,14 @@ sequenceDiagram
         Note left of ESP: UPDATE_STATUS_FAIL_ALREADY_UP_TO_DATE
     else Newer release available
         OTA->>GH: GET firmware binary URL
-        Note right of OTA: Binary cached 30 minutes per file
-        OTA-->>ESP: 200 octet-stream plus Content-Length
-        Note left of ESP: Update.begin and writeStream
+        Note right of OTA: Verified against GitHub sha256, cached 30 minutes per file
+        OTA-->>ESP: 200 octet-stream, Content-Length, X-Firmware-MD5
+        Note left of ESP: Update.begin, setMD5, writeStream
+        alt MD5 matches
+            Note left of ESP: Boot partition switched, reboot unconfirmed
+        else MD5 mismatch
+            Note left of ESP: Boot partition untouched, retry then FAIL_CORRUPT_DOWNLOAD
+        end
     end
 ```
 
@@ -96,5 +111,19 @@ sequenceDiagram
 | 3 | Worker | If newest GitHub tag changed since last cache, delete old `*_firmware.bin` caches |
 | 4 | Worker | Pick the newest release that actually ships `{firmware}_firmware.bin` |
 | 5 | Worker | If `tag` param equals that release's `tag_name` → **204** (already up to date) |
-| 6 | Worker | Else serve `{firmware}_firmware.bin` from that release, cache or GitHub → **200** |
-| 7 | ESP32 | Flash via `Update` API and restart |
+| 6 | Worker | Else fetch `{firmware}_firmware.bin` (cache or GitHub), check it against the asset's GitHub `sha256` digest (**502** on mismatch), serve → **200** |
+| 7 | Worker | Set `X-Firmware-MD5` to the MD5 of that exact body |
+| 8 | ESP32 | Flash via `Update` API, reject the image if the MD5 does not match, then restart |
+| 9 | ESP32 | New image boots `PENDING_VERIFY`; confirmed after `OTA_VERIFY_CONFIRM_MS` of `loop()`, reverted if it reboots first |
+
+## Failure modes and what catches them
+
+| What goes wrong | Caught by | Result |
+|-----------------|-----------|--------|
+| Worker's copy from GitHub corrupted | Worker checks it against the asset's GitHub `sha256` | **502**, never cached; device retries and the worker refetches |
+| Transfer truncated | `written != fileSize` | Retry; running firmware untouched |
+| Body corrupted between worker and device | `Update.setMD5` against `X-Firmware-MD5` | Retry, then `FAIL_CORRUPT_DOWNLOAD`; boot partition never switched |
+| Image corrupt past the MD5 (e.g. bad flash write) | Bootloader image verification | Boots the other slot |
+| Image can't boot (crash / boot loop in setup or early tasks) | Bootloader sees `PENDING_VERIFY` on the reboot | Boots the previous slot |
+| Image hangs before it is confirmed | Bootloader, on the next reboot or power cycle | Boots the previous slot |
+| Image boots but misbehaves | Not covered -- releases are tested before publishing | Stays installed |

--- a/ESP32_SHARED_LIBS/src/oasman-ota_flowchart.md
+++ b/ESP32_SHARED_LIBS/src/oasman-ota_flowchart.md
@@ -107,12 +107,12 @@ sequenceDiagram
 | Step | Who | What |
 |------|-----|------|
 | 1 | ESP32 | `GET oasman-ota?firmware=...&tag=...` |
-| 2 | Worker | Load or fetch `releases` list (30 min cache) |
+| 2 | Worker | Load or fetch `releases` list (30 min cache; authenticated with `GITHUB_TOKEN` if set) |
 | 3 | Worker | If newest GitHub tag changed since last cache, delete old `*_firmware.bin` caches |
 | 4 | Worker | Pick the newest release that actually ships `{firmware}_firmware.bin` |
 | 5 | Worker | If `tag` param equals that release's `tag_name` → **204** (already up to date) |
 | 6 | Worker | Else fetch `{firmware}_firmware.bin` (cache or GitHub), check it against the asset's GitHub `sha256` digest (**502** on mismatch), serve → **200** |
-| 7 | Worker | Set `X-Firmware-MD5` to the MD5 of that exact body |
+| 7 | Worker | Set `X-Firmware-MD5`, computed once when the file is downloaded and stored with the cached copy |
 | 8 | ESP32 | Flash via `Update` API, reject the image if the MD5 does not match, then restart |
 | 9 | ESP32 | New image boots `PENDING_VERIFY`; confirmed after `OTA_VERIFY_CONFIRM_MS` of `loop()`, reverted if it reboots first |
 
@@ -122,8 +122,11 @@ sequenceDiagram
 |-----------------|-----------|--------|
 | Worker's copy from GitHub corrupted | Worker checks it against the asset's GitHub `sha256` | **502**, never cached; device retries and the worker refetches |
 | Transfer truncated | `written != fileSize` | Retry; running firmware untouched |
-| Body corrupted between worker and device | `Update.setMD5` against `X-Firmware-MD5` | Retry, then `FAIL_CORRUPT_DOWNLOAD`; boot partition never switched |
+| Cached copy or body corrupted after the worker verified it | `Update.setMD5` against `X-Firmware-MD5` | Retry, then `FAIL_CORRUPT_DOWNLOAD`; boot partition never switched |
 | Image corrupt past the MD5 (e.g. bad flash write) | Bootloader image verification | Boots the other slot |
 | Image can't boot (crash / boot loop in setup or early tasks) | Bootloader sees `PENDING_VERIFY` on the reboot | Boots the previous slot |
 | Image hangs before it is confirmed | Bootloader, on the next reboot or power cycle | Boots the previous slot |
 | Image boots but misbehaves | Not covered -- releases are tested before publishing | Stays installed |
+
+Every GitHub request that fails to connect or returns a non-2xx status is logged with `console.error` as
+`GitHub <request> rejected: HTTP <status> ...`, so it shows up in the worker's Cloudflare logs.

--- a/ESP32_SHARED_LIBS/src/oasman-ota_worker.js
+++ b/ESP32_SHARED_LIBS/src/oasman-ota_worker.js
@@ -2,7 +2,8 @@
  * OASMan unified OTA worker
  * GET ?firmware=<FIRMWARE_RELEASE_NAME>&tag=<RELEASE_TAG_NAME>
  * - 204 if newest release (for that firmware) tag matches tag (already up to date)
- * - 200 + firmware binary if a newer release is available
+ * - 200 + firmware binary if a newer release is available, plus X-Firmware-MD5 of that body
+ * - 502 if the binary fetched from GitHub does not match the asset's sha256 digest
  * - blank/missing tag is treated as outdated (serve the newest matching binary)
  * Deploy as: oasman-ota → http://oasman-ota.gopro2027.workers.dev/
  */
@@ -21,9 +22,33 @@ const BINARY_URL_PREFIX =
 const FIRMWARE_NAME_RE = /^[a-zA-Z0-9_]+$/;
 const CACHE_TTL_MS = 30 * 60 * 1000;
 /** Bump when binary cache/response format changes (v1 streamed bodies broke ESP32 HTTPClient). */
-const BINARY_CACHE_VERSION = 'v2-buffered';
+const BINARY_CACHE_VERSION = 'v3-md5';
 
 const FIRMWARE_BIN_SUFFIX = '_firmware.bin';
+
+function toHex(digest) {
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/** MD5 of the bytes actually being sent, for the device's Update.setMD5(). Null if unavailable. */
+async function firmwareMd5Hex(body) {
+  try {
+    return toHex(await crypto.subtle.digest('MD5', body));
+  } catch (err) {
+    console.log(`MD5 unavailable, serving firmware without an integrity header: ${err}`);
+    return null;
+  }
+}
+
+/** Check firmware bytes against GitHub's asset digest ("sha256:<hex>"). No digest = unverifiable, allowed. */
+async function matchesGithubDigest(buffer, expectedDigest) {
+  if (!expectedDigest?.startsWith('sha256:')) {
+    console.log(`No sha256 digest from GitHub (${expectedDigest}), serving firmware unverified`);
+    return true;
+  }
+  const actual = toHex(await crypto.subtle.digest('SHA-256', buffer));
+  return actual === expectedDigest.slice('sha256:'.length).toLowerCase();
+}
 
 function binaryCacheRequest(downloadUrl) {
   return new Request(`${downloadUrl}#${BINARY_CACHE_VERSION}`, { method: 'GET' });
@@ -176,9 +201,13 @@ function findReleaseWithFirmware(releases, firmware) {
  * Fixed-length firmware body for ESP32 HTTPClient (must not use chunked Transfer-Encoding).
  * Body is a Uint8Array copy so Content-Length always matches bytes on the wire.
  */
-function binaryResponse(buffer, extraHeaders = {}) {
+async function binaryResponse(buffer, extraHeaders = {}) {
   const body = new Uint8Array(buffer);
   const headers = new Headers(extraHeaders);
+  const md5 = await firmwareMd5Hex(body);
+  if (md5) {
+    headers.set('X-Firmware-MD5', md5);
+  }
   headers.set('Content-Type', 'application/octet-stream');
   headers.set('Content-Length', String(body.byteLength));
   headers.set('Connection', 'close');
@@ -187,7 +216,7 @@ function binaryResponse(buffer, extraHeaders = {}) {
   return new Response(body, { status: 200, headers });
 }
 
-async function proxyBinary(downloadUrl, ctx) {
+async function proxyBinary(downloadUrl, expectedDigest, ctx) {
   if (!downloadUrl || !downloadUrl.startsWith(BINARY_URL_PREFIX)) {
     return new Response('Invalid download URL', { status: 400 });
   }
@@ -200,11 +229,16 @@ async function proxyBinary(downloadUrl, ctx) {
     const cacheExpiry = cachedResponse.headers.get('X-Cache-Expiry');
     if (cacheExpiry && Date.now() < parseInt(cacheExpiry, 10)) {
       const buffer = await cachedResponse.arrayBuffer();
-      return binaryResponse(buffer, {
-        'X-Cache-Hit': 'true',
-        'X-Cache-Time': cachedResponse.headers.get('X-Cache-Time'),
-        'X-Cache-Expiry': cacheExpiry,
-      });
+      if (await matchesGithubDigest(buffer, expectedDigest)) {
+        return await binaryResponse(buffer, {
+          'X-Cache-Hit': 'true',
+          'X-Cache-Time': cachedResponse.headers.get('X-Cache-Time'),
+          'X-Cache-Expiry': cacheExpiry,
+        });
+      }
+      console.log(`Cached firmware failed its sha256 check, refetching ${downloadUrl}`);
+      await cache.delete(cacheKey);
+      cachedResponse = null;
     }
   }
 
@@ -216,12 +250,14 @@ async function proxyBinary(downloadUrl, ctx) {
   if (response.status === 403 || response.status === 429) {
     if (cachedResponse) {
       const buffer = await cachedResponse.arrayBuffer();
-      return binaryResponse(buffer, {
-        'X-Cache-Hit': 'true',
-        'X-Cache-Time': cachedResponse.headers.get('X-Cache-Time'),
-        'X-Rate-Limited': 'true',
-        'X-Rate-Limit-Reset': rateLimitReset || 'unknown',
-      });
+      if (await matchesGithubDigest(buffer, expectedDigest)) {
+        return await binaryResponse(buffer, {
+          'X-Cache-Hit': 'true',
+          'X-Cache-Time': cachedResponse.headers.get('X-Cache-Time'),
+          'X-Rate-Limited': 'true',
+          'X-Rate-Limit-Reset': rateLimitReset || 'unknown',
+        });
+      }
     }
     return new Response(
       JSON.stringify({
@@ -250,6 +286,14 @@ async function proxyBinary(downloadUrl, ctx) {
   }
 
   const buffer = await response.arrayBuffer();
+  // Never cache or serve a bad download; a non-200 makes the device retry, which refetches.
+  if (!(await matchesGithubDigest(buffer, expectedDigest))) {
+    console.log(`Downloaded firmware failed its sha256 check against GitHub: ${downloadUrl}`);
+    return new Response(
+      JSON.stringify({ error: 'Downloaded firmware did not match the GitHub sha256 digest' }),
+      { status: 502, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
   const responseToCache = new Response(buffer, {
     status: 200,
     headers: {
@@ -262,7 +306,7 @@ async function proxyBinary(downloadUrl, ctx) {
   });
   ctx.waitUntil(cache.put(cacheKey, responseToCache));
 
-  return binaryResponse(buffer, {
+  return await binaryResponse(buffer, {
     'X-Cache-Hit': 'false',
     'X-Cache-Time': new Date(now).toISOString(),
   });
@@ -328,6 +372,6 @@ export default {
       });
     }
 
-    return proxyBinary(match.asset.browser_download_url, ctx);
+    return proxyBinary(match.asset.browser_download_url, match.asset.digest, ctx);
   },
 };

--- a/ESP32_SHARED_LIBS/src/oasman-ota_worker.js
+++ b/ESP32_SHARED_LIBS/src/oasman-ota_worker.js
@@ -6,6 +6,7 @@
  * - 502 if the binary fetched from GitHub does not match the asset's sha256 digest
  * - blank/missing tag is treated as outdated (serve the newest matching binary)
  * Deploy as: oasman-ota → http://oasman-ota.gopro2027.workers.dev/
+ * Optional GITHUB_TOKEN (Worker secret or Secrets Store binding; fine-grained, public repos read-only) lifts the GitHub API limit from 60/hr per IP to 5000/hr.
  */
 
 /**
@@ -26,11 +27,14 @@ const BINARY_CACHE_VERSION = 'v3-md5';
 
 const FIRMWARE_BIN_SUFFIX = '_firmware.bin';
 
+// Worker secret (a string) or Secrets Store binding (an object with get()); githubToken() handles both.
+const GITHUB_TOKEN_BINDING = 'GITHUB_TOKEN';
+
 function toHex(digest) {
   return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
 }
 
-/** MD5 of the bytes actually being sent, for the device's Update.setMD5(). Null if unavailable. */
+/** MD5 for the device's Update.setMD5(), computed once per download and stored with the cached copy. Null if unavailable. */
 async function firmwareMd5Hex(body) {
   try {
     return toHex(await crypto.subtle.digest('MD5', body));
@@ -93,7 +97,56 @@ function releasesTagFromCache(cachedResponse, releases) {
   return cachedResponse?.headers.get('X-Release-Tag') || newestReleaseTag(releases);
 }
 
-async function fetchCachedReleasesJson() {
+/** Every GitHub request goes through here so any rejection or connection failure lands in the Cloudflare logs. */
+async function githubFetch(what, url, init) {
+  let response;
+  try {
+    response = await fetch(url, init);
+  } catch (err) {
+    console.error(`GitHub ${what} failed to connect: ${err} ${url}`);
+    throw err;
+  }
+  if (!response.ok) {
+    const detail = ['x-ratelimit-remaining', 'x-ratelimit-reset', 'retry-after']
+      .filter((k) => response.headers.has(k))
+      .map((k) => `${k}=${response.headers.get(k)}`)
+      .join(' ');
+    console.error(`GitHub ${what} rejected: HTTP ${response.status} ${detail ? detail + ' ' : ''}${url}`);
+  }
+  return response;
+}
+
+async function githubToken(env) {
+  const secret = env?.[GITHUB_TOKEN_BINDING];
+  if (typeof secret?.get === 'function') {
+    try {
+      return await secret.get();
+    } catch (err) {
+      console.error(`Could not read ${GITHUB_TOKEN_BINDING} from the Secrets Store: ${err}`);
+      return null;
+    }
+  }
+  return secret || null;
+}
+
+// Only the API call is authenticated; release downloads redirect off github.com and must never carry the token.
+async function fetchReleasesFromGithub(env) {
+  const headers = { 'User-Agent': 'OASMan-OTA/1.0', Accept: 'application/vnd.github+json' };
+  const token = await githubToken(env);
+  if (token) {
+    const authed = await githubFetch('releases API (token)', RELEASES_LIST_URL, {
+      headers: { ...headers, Authorization: `Bearer ${token}` },
+    });
+    if (authed.status !== 401) {
+      return authed;
+    }
+    await authed.body?.cancel();
+    console.warn('GitHub token rejected (expired or revoked?), falling back to unauthenticated');
+  }
+  return githubFetch('releases API', RELEASES_LIST_URL, { headers });
+}
+
+async function fetchCachedReleasesJson(env) {
   const cacheKey = new Request(RELEASES_LIST_URL, { method: 'GET' });
   const cache = caches.default;
   const cachedResponse = await cache.match(cacheKey);
@@ -110,12 +163,11 @@ async function fetchCachedReleasesJson() {
     }
   }
 
-  const response = await fetch(RELEASES_LIST_URL, {
-    headers: {
-      'User-Agent': 'OASMan-OTA/1.0',
-      Accept: 'application/vnd.github+json',
-    },
-  });
+  const response = await fetchReleasesFromGithub(env);
+  if (response.ok) {
+    // 5000 means the token is in use, 60 means these calls are unauthenticated.
+    console.log(`GitHub releases API ${response.status}, rate limit ${response.headers.get('x-ratelimit-limit')}/hr`);
+  }
 
   const buffer = await response.arrayBuffer();
   const now = Date.now();
@@ -201,10 +253,9 @@ function findReleaseWithFirmware(releases, firmware) {
  * Fixed-length firmware body for ESP32 HTTPClient (must not use chunked Transfer-Encoding).
  * Body is a Uint8Array copy so Content-Length always matches bytes on the wire.
  */
-async function binaryResponse(buffer, extraHeaders = {}) {
+function binaryResponse(buffer, md5, extraHeaders = {}) {
   const body = new Uint8Array(buffer);
   const headers = new Headers(extraHeaders);
-  const md5 = await firmwareMd5Hex(body);
   if (md5) {
     headers.set('X-Firmware-MD5', md5);
   }
@@ -223,41 +274,37 @@ async function proxyBinary(downloadUrl, expectedDigest, ctx) {
 
   const cacheKey = binaryCacheRequest(downloadUrl);
   const cache = caches.default;
-  let cachedResponse = await cache.match(cacheKey);
+  const cachedResponse = await cache.match(cacheKey);
+  // Entries without a stored MD5 predate this format and are treated as a miss.
+  const cachedMd5 = cachedResponse?.headers.get('X-Firmware-MD5');
 
-  if (cachedResponse) {
+  // No hashing on a hit: bytes were verified before caching, and the stored MD5 lets the device catch corruption.
+  if (cachedResponse && cachedMd5) {
     const cacheExpiry = cachedResponse.headers.get('X-Cache-Expiry');
     if (cacheExpiry && Date.now() < parseInt(cacheExpiry, 10)) {
       const buffer = await cachedResponse.arrayBuffer();
-      if (await matchesGithubDigest(buffer, expectedDigest)) {
-        return await binaryResponse(buffer, {
-          'X-Cache-Hit': 'true',
-          'X-Cache-Time': cachedResponse.headers.get('X-Cache-Time'),
-          'X-Cache-Expiry': cacheExpiry,
-        });
-      }
-      console.log(`Cached firmware failed its sha256 check, refetching ${downloadUrl}`);
-      await cache.delete(cacheKey);
-      cachedResponse = null;
+      return binaryResponse(buffer, cachedMd5, {
+        'X-Cache-Hit': 'true',
+        'X-Cache-Time': cachedResponse.headers.get('X-Cache-Time'),
+        'X-Cache-Expiry': cacheExpiry,
+      });
     }
   }
 
-  const response = await fetch(downloadUrl);
+  const response = await githubFetch('firmware download', downloadUrl);
   const now = Date.now();
   const cacheExpiry = now + CACHE_TTL_MS;
   const rateLimitReset = response.headers.get('x-ratelimit-reset');
 
   if (response.status === 403 || response.status === 429) {
-    if (cachedResponse) {
+    if (cachedResponse && cachedMd5) {
       const buffer = await cachedResponse.arrayBuffer();
-      if (await matchesGithubDigest(buffer, expectedDigest)) {
-        return await binaryResponse(buffer, {
-          'X-Cache-Hit': 'true',
-          'X-Cache-Time': cachedResponse.headers.get('X-Cache-Time'),
-          'X-Rate-Limited': 'true',
-          'X-Rate-Limit-Reset': rateLimitReset || 'unknown',
-        });
-      }
+      return binaryResponse(buffer, cachedMd5, {
+        'X-Cache-Hit': 'true',
+        'X-Cache-Time': cachedResponse.headers.get('X-Cache-Time'),
+        'X-Rate-Limited': 'true',
+        'X-Rate-Limit-Reset': rateLimitReset || 'unknown',
+      });
     }
     return new Response(
       JSON.stringify({
@@ -288,25 +335,26 @@ async function proxyBinary(downloadUrl, expectedDigest, ctx) {
   const buffer = await response.arrayBuffer();
   // Never cache or serve a bad download; a non-200 makes the device retry, which refetches.
   if (!(await matchesGithubDigest(buffer, expectedDigest))) {
-    console.log(`Downloaded firmware failed its sha256 check against GitHub: ${downloadUrl}`);
+    console.error(`Downloaded firmware failed its sha256 check against GitHub: ${downloadUrl}`);
     return new Response(
       JSON.stringify({ error: 'Downloaded firmware did not match the GitHub sha256 digest' }),
       { status: 502, headers: { 'Content-Type': 'application/json' } }
     );
   }
-  const responseToCache = new Response(buffer, {
-    status: 200,
-    headers: {
-      'Content-Type': 'application/octet-stream',
-      'Content-Length': String(buffer.byteLength),
-      'X-Cache-Expiry': cacheExpiry.toString(),
-      'X-Cache-Time': new Date(now).toISOString(),
-      'Cache-Control': 'public, max-age=1800',
-    },
-  });
-  ctx.waitUntil(cache.put(cacheKey, responseToCache));
+  const md5 = await firmwareMd5Hex(buffer);
+  const cacheHeaders = {
+    'Content-Type': 'application/octet-stream',
+    'Content-Length': String(buffer.byteLength),
+    'X-Cache-Expiry': cacheExpiry.toString(),
+    'X-Cache-Time': new Date(now).toISOString(),
+    'Cache-Control': 'public, max-age=1800',
+  };
+  if (md5) {
+    cacheHeaders['X-Firmware-MD5'] = md5;
+  }
+  ctx.waitUntil(cache.put(cacheKey, new Response(buffer, { status: 200, headers: cacheHeaders })));
 
-  return await binaryResponse(buffer, {
+  return binaryResponse(buffer, md5, {
     'X-Cache-Hit': 'false',
     'X-Cache-Time': new Date(now).toISOString(),
   });
@@ -340,7 +388,7 @@ export default {
       });
     }
 
-    const releaseResult = await fetchCachedReleasesJson();
+    const releaseResult = await fetchCachedReleasesJson(env);
     if (!releaseResult.ok) {
       const headers = { 'Content-Type': 'application/json' };
       if (releaseResult.status === 429) {

--- a/ESP32_SHARED_LIBS/src/otarollback.cpp
+++ b/ESP32_SHARED_LIBS/src/otarollback.cpp
@@ -1,0 +1,30 @@
+#include "otarollback.h"
+
+#include <esp_ota_ops.h>
+
+// Must be extern "C" (the weak default is in the core's esp32-hal-misc.c, unmangled) and must
+// stay in the same file as otaVerifyLoop(), or the linker never pulls it out of the archive.
+// By default the bootloader will cancel the rollback via it's own checks inside of the bootloader code, but we want to wait to cancel the rollback in our own code to make sure setup runs before we cancel the rollback. So this function tells the bootloader 'hey! I will manually decide when to cancel the rollback and mark the update as valid.'
+extern "C" bool verifyRollbackLater()
+{
+    return true;
+}
+
+void otaVerifyLoop()
+{
+    static const unsigned long firstLoopMs = millis();
+    static bool done = false;
+    if (done || millis() - firstLoopMs < OTA_VERIFY_CONFIRM_MS)
+    {
+        return;
+    }
+    done = true;
+
+    esp_ota_img_states_t state;
+    if (esp_ota_get_state_partition(esp_ota_get_running_partition(), &state) == ESP_OK &&
+        state == ESP_OTA_IMG_PENDING_VERIFY)
+    {
+        esp_err_t err = esp_ota_mark_app_valid_cancel_rollback();
+        log_i("OTA verify: new image ran %lums, confirm result %d", OTA_VERIFY_CONFIRM_MS, (int)err);
+    }
+}

--- a/ESP32_SHARED_LIBS/src/otarollback.h
+++ b/ESP32_SHARED_LIBS/src/otarollback.h
@@ -1,0 +1,14 @@
+#ifndef otarollback_h
+#define otarollback_h
+
+#include <Arduino.h>
+
+// A new OTA image stays unconfirmed until loop() has run this long; any reboot before then reverts it.
+#ifndef OTA_VERIFY_CONFIRM_MS
+#define OTA_VERIFY_CONFIRM_MS 5000UL
+#endif
+
+// Call every loop().
+void otaVerifyLoop();
+
+#endif

--- a/OASMan_ESP32/platformio.ini
+++ b/OASMan_ESP32/platformio.ini
@@ -34,7 +34,8 @@ build_flags =
 
 lib_extra_dirs = ../ESP32_SHARED_LIBS/
 board_build.filesystem = spiffs
-board_build.partitions = min_spiffs.csv ; huge_app.csv  -- no ota ; oasman_partition.csv ;
+; Must stay dual-app-slot or OTA and rollback both silently stop working. ; was: min_spiffs.csv ; huge_app.csv  -- no ota ; oasman_partition.csv ;
+board_build.partitions = min_spiffs.csv
 lib_deps = 
     adafruit/Adafruit ADS1X15@^2.5.0
     ;

--- a/OASMan_ESP32/src/aiPressureUtil.cpp
+++ b/OASMan_ESP32/src/aiPressureUtil.cpp
@@ -260,6 +260,11 @@ static double getPredictionOffset(SOLENOID_AI_INDEX aiIndex, double raw_bag, dou
     // The models are shared between modes, so the untrained default follows whichever mode is active.
     double magnitude = getheightSensorMode() ? (double)OFFSET_DEFAULT_LEVEL : (double)OFFSET_DEFAULT_PSI;
     double def = m->up ? -magnitude : magnitude;
+    // Fix for airing out when preset < OFFSET_DEFAULT_PSI (aka 5psi), it would have never been able to calculate 0 (goes to max timeout). So just allow it to return raw_bag instead so it can get to 0.
+    if (!m->up && raw_bag < magnitude)
+    {
+        def = raw_bag;
+    }
     int count = getLearnDataLength(aiIndex);
     if (count < OFFSET_FADE_MIN)
     {

--- a/OASMan_ESP32/src/bluetooth/ble.cpp
+++ b/OASMan_ESP32/src/bluetooth/ble.cpp
@@ -870,6 +870,9 @@ void runReceivedPacket(hci_con_handle_t con_handle, BTOasPacket *packet)
         case UPDATE_STATUS::UPDATE_STATUS_FAIL_WIFI_NO_NETWORK:
             pkt.setStatus("[F] No SSID");
             break;
+        case UPDATE_STATUS::UPDATE_STATUS_FAIL_CORRUPT_DOWNLOAD:
+            pkt.setStatus("[F] Corrupt");
+            break;
         case UPDATE_STATUS::UPDATE_STATUS_FAIL_ALREADY_UP_TO_DATE:
         case UPDATE_STATUS::UPDATE_STATUS_NONE:
         case UPDATE_STATUS::UPDATE_STATUS_SUCCESS:

--- a/OASMan_ESP32/src/main.cpp
+++ b/OASMan_ESP32/src/main.cpp
@@ -11,6 +11,7 @@
 #include "airSuspensionUtil.h"
 #include "tasks/tasks.h"
 #include <directdownload.h>
+#include <otarollback.h>
 
 #include <SPIFFS.h>
 
@@ -112,6 +113,8 @@ void setup()
 
 void loop()
 {
+    otaVerifyLoop();
+
     accessoryWireLoop();
     ebrakeWireLoop();
     if (getinternalReboot() == true)

--- a/Wireless_Controller/src/main.cpp
+++ b/Wireless_Controller/src/main.cpp
@@ -4,6 +4,7 @@
 #if defined(OTA_SUPPORTED)
 #include <directdownload.h>
 #endif
+#include <otarollback.h> // not behind OTA_SUPPORTED: any build may be running an unconfirmed image
 
 #include <ui/ui.h>
 
@@ -117,6 +118,10 @@ void setup()
         case UPDATE_STATUS::UPDATE_STATUS_FAIL_WIFI_NO_NETWORK:
             showDialog("Update failed (wifi not found)", lv_color_hex(0xFF0000));
             currentScr->showMsgBox("Update failed", "Could not find that wifi network. Please check your wifi SSID and that the network is in range", NULL, "OK", []() -> void {}, []() -> void {}, false);
+            break;
+        case UPDATE_STATUS::UPDATE_STATUS_FAIL_CORRUPT_DOWNLOAD:
+            showDialog("Update failed (corrupt download)", lv_color_hex(0xFF0000));
+            currentScr->showMsgBox("Update failed", "The downloaded firmware did not match its checksum, so it was not installed. Your device is untouched. Please try again", NULL, "OK", []() -> void {}, []() -> void {}, false);
             break;
         case UPDATE_STATUS::UPDATE_STATUS_FAIL_ALREADY_UP_TO_DATE:
             showDialog("Update not needed", lv_color_hex(0xFFFF00));
@@ -279,6 +284,8 @@ void bootButtonFunctionality() {
 void loop()
 {
     auto const now = millis();
+
+    otaVerifyLoop();
 
     bootButtonFunctionality();
 

--- a/Wireless_Controller/src/ui/screens/ui_scrSettings.cpp
+++ b/Wireless_Controller/src/ui/screens/ui_scrSettings.cpp
@@ -1092,7 +1092,7 @@ void ScrSettings::init(lv_obj_t *parent)
 #if defined(OTA_SUPPORTED)
                 runNextFrame([]() -> void
                 {
-                    currentScr->showMsgBox("Updating in progress...",
+                    currentScr->showMsgBox("Updating in progress",
                         "Both the manifold & controller are installing their updates. Both will reboot when completed.",
                         NULL, "OK", []() -> void {}, []() -> void {}, false);
                     runNextFrame([]() -> void
@@ -1104,7 +1104,7 @@ void ScrSettings::init(lv_obj_t *parent)
                     log_i("Attempted to download update");
                 });
 #else
-                currentScr->showMsgBox("Updating in progress...",
+                currentScr->showMsgBox("Updating in progress",
                     "The manifold is installing the latest update. Your controller does not support OTA updates. Please go to http://oasman.dev on your computer to flash the latest update to your controller.",
                     NULL, "OK",
                     []() -> void { ESP.restart(); },

--- a/Wireless_Controller/src/ui/screens/ui_scrSettings.cpp
+++ b/Wireless_Controller/src/ui/screens/ui_scrSettings.cpp
@@ -1115,7 +1115,24 @@ void ScrSettings::init(lv_obj_t *parent)
     });
 
     updateUpdateButtonVisbility();
-    this->ui_manifoldUpdateStatus = new Option(wifi_update_page, OptionType::TEXT_WITH_VALUE, "Manifold:", {.STRING = test});
+
+    // Version and info
+    this->ui_manifoldUpdateStatus = new Option(wifi_update_page, OptionType::TEXT_WITH_VALUE, "Manifold Version:", {.STRING = "Not connected"});
+
+    OptionValue versionValue;
+#ifdef OFFICIAL_RELEASE
+    versionValue.STRING = EVALUATE_AND_STRINGIFY(RELEASE_VERSION);
+#else
+    versionValue.STRING = "DEVELOPMENT";
+#endif
+    allOptions.push_back(new Option(wifi_update_page, OptionType::TEXT_WITH_VALUE, "Controller Version:", versionValue));
+    this->ui_mac = new Option(wifi_update_page, OptionType::TEXT_WITH_VALUE, "Manifold MAC:", {.STRING = ble_getMAC()});
+#if HAS_BATTERY_SENSE_READING
+    this->ui_volts = new Option(wifi_update_page, OptionType::TEXT_WITH_VALUE, "Battery:", {.STRING = getBatteryVoltageString()});
+#else
+    // Nothing to report -- this board has no battery sense. See HAS_BATTERY_SENSE_READING.
+    this->ui_volts = nullptr;
+#endif
 
     // QR Code - scaled for display size
     const int qrSize = scaledX(100);
@@ -1128,25 +1145,9 @@ void ScrSettings::init(lv_obj_t *parent)
     lv_qrcode_set_dark_color(this->ui_qrcode, lv_color_black());
     lv_qrcode_set_light_color(this->ui_qrcode, lv_color_white());
 
-    const char *qr_data = "https://oasman.dev";
+    const char *qr_data = "https://oasman.co";
     lv_qrcode_update(this->ui_qrcode, qr_data, strlen(qr_data));
     lv_obj_set_x(this->ui_qrcode, scrW / 2 - qrSize / 2);
-
-    // Version and info
-    OptionValue versionValue;
-#ifdef OFFICIAL_RELEASE
-    versionValue.STRING = EVALUATE_AND_STRINGIFY(RELEASE_VERSION);
-#else
-    versionValue.STRING = "DEVELOPMENT";
-#endif
-    allOptions.push_back(new Option(wifi_update_page, OptionType::TEXT_WITH_VALUE, "Version:", versionValue));
-    this->ui_mac = new Option(wifi_update_page, OptionType::TEXT_WITH_VALUE, "Manifold:", {.STRING = ble_getMAC()});
-#if HAS_BATTERY_SENSE_READING
-    this->ui_volts = new Option(wifi_update_page, OptionType::TEXT_WITH_VALUE, "Battery:", {.STRING = getBatteryVoltageString()});
-#else
-    // Nothing to report -- this board has no battery sense. See HAS_BATTERY_SENSE_READING.
-    this->ui_volts = nullptr;
-#endif
 
     // Restore previously selected page (or default to Status)
     if (saved_page_index < 0 || saved_page_index >= this->settingsPageCount) {


### PR DESCRIPTION
Added md5 checks on ota, and also postpone the ota rollback cancellation check code to 5s after boot instead of letting the bootloader decide, this way we can ensure the setup function runs before deciding that the firmware is good.